### PR TITLE
Add Dockerfile for sample apps and enable publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-jre-alpine
+MAINTAINER YugaByte
+ENV container=yb-sample-apps
+
+WORKDIR /opt/yugabyte
+
+ARG JAR_FILE
+ADD target/${JAR_FILE} /opt/yugabyte/yb-sample-apps.jar
+
+ENTRYPOINT ["/usr/bin/java", "-jar", "/opt/yugabyte/yb-sample-apps.jar"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You need the following to build:
 
 To build, simply run the following:
 ```
-$ mvn -DskipTests package
+$ mvn -DskipTests -DskipDockerBuild package
 ```
 
 You can find the executable one-jar at the following location:
@@ -83,3 +83,7 @@ $ ls target/yb-sample-apps.jar
 target/yb-sample-apps.jar
 ```
 
+To docker image with the package, simply run the following:
+```
+$ mvn package
+```

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <maven-dependency-plugin.phase>prepare-package</maven-dependency-plugin.phase>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <skipDockerBuildBuild>false</skipDockerBuildBuild>
   </properties>
 
   <dependencies>
@@ -166,6 +167,7 @@
           <buildArgs>
             <JAR_FILE>${project.artifactId}.jar</JAR_FILE>
           </buildArgs>
+          <skip>${skipDockerBuild}</skip>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,28 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>dockerfile-maven-plugin</artifactId>
+        <version>1.4.10</version>
+        <executions>
+          <execution>
+            <id>default</id>
+            <goals>
+              <goal>build</goal>
+              <goal>push</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <repository>yugabytedb/yb-sample-apps</repository>
+          <tag>${project.version}</tag>
+          <buildArgs>
+            <JAR_FILE>${project.artifactId}.jar</JAR_FILE>
+          </buildArgs>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Adding the option to generate docker image out of yb-sample-apps and publish it to dockerhub

Run package command to build and generate the docker image locally
`mvn package`

To just package without generating the docker image you need to run
`mvn package -DskipDockerBuild`

You can run following command to publish to our docker hub registry.
`docker push yugabytedb/yb-sample-apps:<version>` 

To run the sample apps in background
`docker run -id yugabytedb/yb-sample-apps:1.0 --workload CassandraKeyValue --nodes <node ips>`

