### PR TITLE
Misc fixes to YSQL sample apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target
+.idea
+yb-sample-apps.iml

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -103,11 +103,8 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   // Is this app instance the main instance?
   private boolean mainInstance = false;
 
-  // Keyspace name.
+  // YCQL keyspace name.
   public static String keyspace = "ybdemo_keyspace";
-
-  // Postgres database name for workload.
-  public static String postgres_ybdemo_database = "ybdemo_database";
 
   //////////// Helper methods to return the client objects (Redis, Cassandra, etc). ////////////////
 
@@ -517,11 +514,18 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
    */
   public List<String> getWorkloadDescription() { return Collections.EMPTY_LIST; }
 
+
   /**
-   * Returns the example usage of the app.
-   * @return the example usage splitted in lines.
+   * Returns any workload-specific required command line options.
+   * @return the options split in lines.
    */
-  public List<String> getExampleUsageOptions() { return Collections.EMPTY_LIST; }
+  public List<String> getWorkloadRequiredArguments() {return Collections.EMPTY_LIST; }
+
+  /**
+   * Returns any workload-specific optional command line options.
+   * @return the options split in lines.
+   */
+  public List<String> getWorkloadOptionalArguments() { return Collections.EMPTY_LIST; }
 
   ////////////// The following methods framework/helper methods for subclasses. ////////////////////
 
@@ -608,7 +612,7 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
    */
   public void performWrite(int threadIdx) {
     // If we have written enough keys we are done.
-    if (appConfig.numKeysToWrite > 0 && numKeysWritten.get() >= appConfig.numKeysToWrite
+    if (appConfig.numKeysToWrite >= 0 && numKeysWritten.get() >= appConfig.numKeysToWrite
         || isOutOfTime()) {
       hasFinished.set(true);
       return;
@@ -631,8 +635,9 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
    * report the metrics to the user.
    */
   public void performRead() {
+
     // If we have read enough keys we are done.
-    if (appConfig.numKeysToRead > 0 && numKeysRead.get() >= appConfig.numKeysToRead
+    if (appConfig.numKeysToRead >= 0 && numKeysRead.get() >= appConfig.numKeysToRead
         || isOutOfTime()) {
       hasFinished.set(true);
       return;

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
@@ -87,7 +87,7 @@ public class CassandraBatchKeyValue extends CassandraKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
@@ -301,7 +301,7 @@ public class CassandraBatchTimeseries extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -190,7 +190,7 @@ public abstract class CassandraKeyValueBase extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
@@ -264,7 +264,7 @@ public class CassandraPersonalization extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
@@ -160,7 +160,7 @@ public class CassandraSecondaryIndex extends CassandraKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
@@ -315,7 +315,7 @@ public class CassandraStockTicker extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
@@ -381,7 +381,7 @@ public class CassandraTimeseries extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalKeyValue.java
@@ -156,7 +156,7 @@ public class CassandraTransactionalKeyValue extends CassandraKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalRestartRead.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalRestartRead.java
@@ -148,7 +148,7 @@ public class CassandraTransactionalRestartRead extends CassandraKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/CassandraUniqueSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraUniqueSecondaryIndex.java
@@ -61,7 +61,7 @@ public class CassandraUniqueSecondaryIndex extends CassandraSecondaryIndex {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/RedisHashPipelined.java
+++ b/src/main/java/com/yugabyte/sample/apps/RedisHashPipelined.java
@@ -245,8 +245,8 @@ public class RedisHashPipelined extends RedisPipelinedKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
-    Vector<String> usage = new Vector<String>(super.getExampleUsageOptions());
+  public List<String> getWorkloadOptionalArguments() {
+    Vector<String> usage = new Vector<String>(super.getWorkloadOptionalArguments());
     usage.add("--num_subkeys_per_key " + appConfig.numSubkeysPerKey);
     usage.add("--num_subkeys_per_write " + appConfig.numSubkeysPerWrite);
     usage.add("--num_subkeys_per_read " + appConfig.numSubkeysPerRead);

--- a/src/main/java/com/yugabyte/sample/apps/RedisKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/RedisKeyValue.java
@@ -113,7 +113,7 @@ public class RedisKeyValue extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
       "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
       "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/RedisPipelinedKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/RedisPipelinedKeyValue.java
@@ -222,8 +222,8 @@ public class RedisPipelinedKeyValue extends RedisKeyValue {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
-    Vector<String> usage = new Vector<String>(super.getExampleUsageOptions());
+  public List<String> getWorkloadOptionalArguments() {
+    Vector<String> usage = new Vector<String>(super.getWorkloadOptionalArguments());
     usage.add("--pipeline_length " + appConfig.redisPipelineLength);
     return usage;
   }

--- a/src/main/java/com/yugabyte/sample/apps/RedisYBClientKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/RedisYBClientKeyValue.java
@@ -98,7 +98,7 @@ public class RedisYBClientKeyValue extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -76,10 +76,12 @@ public class SqlInserts extends AppBase {
   public void createTablesIfNeeded() throws Exception {
     Connection connection = getPostgresConnection();
 
-    // Create the table.
+    // (Re)Create the table (every run should start cleanly with an empty table).
     connection.createStatement().execute(
-        String.format("CREATE TABLE IF NOT EXISTS %s (k text PRIMARY KEY, v text);",
-            getTableName()));
+        String.format("DROP TABLE IF EXISTS %s", getTableName()));
+    LOG.info("Dropping any table(s) left from previous runs if any");
+    connection.createStatement().execute(
+        String.format("CREATE TABLE %s (k text PRIMARY KEY, v text)", getTableName()));
     LOG.info(String.format("Created table: %s", getTableName()));
   }
 
@@ -90,11 +92,8 @@ public class SqlInserts extends AppBase {
 
   private PreparedStatement getPreparedSelect() throws Exception {
     if (preparedSelect == null) {
-      preparedSelect = getPostgresConnection(postgres_ybdemo_database).prepareStatement(
+      preparedSelect = getPostgresConnection().prepareStatement(
           String.format("SELECT k, v FROM %s WHERE k = ?;", getTableName()));
-      // TODO disable server-side prepare until we handle predicate pushdown with bind-vars better.
-      org.postgresql.PGStatement pgstmt = (org.postgresql.PGStatement)preparedSelect;
-      pgstmt.setUseServerPrepare(false);
     }
     return preparedSelect;
   }
@@ -112,18 +111,17 @@ public class SqlInserts extends AppBase {
       statement.setString(1, key.asString());
       try (ResultSet rs = statement.executeQuery()) {
         if (!rs.next()) {
-          LOG.fatal("Read key: " + key.asString() + " expected 1 row in result, got 0");
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got 0");
           return 0;
         }
 
         if (!key.asString().equals(rs.getString("k"))) {
-          LOG.fatal("Read key: " + key.asString() + ", got " + rs.getString("k"));
+          LOG.error("Read key: " + key.asString() + ", got " + rs.getString("k"));
         }
         LOG.debug("Read key: " + key.toString());
 
         if (rs.next()) {
-          LOG.fatal("Read key: " + key.asString() +
-                        " expected 1 row in result, got more than one");
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got more");
           return 0;
         }
       }
@@ -136,7 +134,7 @@ public class SqlInserts extends AppBase {
 
   private PreparedStatement getPreparedInsert() throws Exception {
     if (preparedInsert == null) {
-      preparedInsert = getPostgresConnection(postgres_ybdemo_database).prepareStatement(
+      preparedInsert = getPostgresConnection().prepareStatement(
           String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()));
     }
     return preparedInsert;
@@ -178,7 +176,7 @@ public class SqlInserts extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -22,6 +22,8 @@ import org.apache.log4j.Logger;
 
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
+import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
+
 /**
  * This workload writes and reads some random string keys from a postgresql table.
  */
@@ -35,8 +37,8 @@ public class SqlSnapshotTxns extends AppBase {
     // Disable the read-write percentage.
     appConfig.readIOPSPercentage = -1;
     // Set the read and write threads to 1 each.
-    appConfig.numReaderThreads = 24;
-    appConfig.numWriterThreads = 2;
+    appConfig.numReaderThreads = 1;
+    appConfig.numWriterThreads = 1;
     // The number of keys to read.
     appConfig.numKeysToRead = -1;
     // The number of keys to write. This is the combined total number of inserts and updates.
@@ -75,19 +77,15 @@ public class SqlSnapshotTxns extends AppBase {
   @Override
   public void createTablesIfNeeded() throws Exception {
     Connection connection = getPostgresConnection();
+    connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    connection.setAutoCommit(false);
 
-    // Check if database already exists.
+    // (Re)Create the table (every run should start cleanly with an empty table).
     connection.createStatement().execute(
-      String.format("CREATE DATABASE IF NOT EXISTS %s", postgres_ybdemo_database));
-    connection.close();
-
-    // Connect to the new database just created.
-    connection = getPostgresConnection(postgres_ybdemo_database);
-
-    // Create the table.
+        String.format("DROP TABLE IF EXISTS %s", getTableName()));
+    LOG.info("Dropping table(s) left from previous runs if any");
     connection.createStatement().executeUpdate(
-        String.format("CREATE TABLE IF NOT EXISTS %s (k varchar PRIMARY KEY, v varchar);",
-            getTableName()));
+        String.format("CREATE TABLE %s (k text PRIMARY KEY, v text);", getTableName()));
     LOG.info(String.format("Created table: %s", getTableName()));
   }
 
@@ -98,7 +96,7 @@ public class SqlSnapshotTxns extends AppBase {
 
   private PreparedStatement getPreparedSelect() throws Exception {
     if (preparedSelect == null) {
-      preparedSelect = getPostgresConnection(postgres_ybdemo_database).prepareStatement(
+      preparedSelect = getPostgresConnection().prepareStatement(
           String.format("SELECT k, v FROM %s WHERE k = ?;", getTableName()));
     }
     return preparedSelect;
@@ -115,21 +113,21 @@ public class SqlSnapshotTxns extends AppBase {
     try {
       PreparedStatement statement = getPreparedSelect();
       statement.setString(1, key.asString());
-      ResultSet rs = statement.executeQuery();
-      if (!rs.next()) {
-        LOG.fatal("Read key: " + key.asString() + " expected 1 row in result, got 0");
-        return 0;
-      }
+      try (ResultSet rs = statement.executeQuery()) {
+        if (!rs.next()) {
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got 0");
+          return 0;
+        }
 
-      if (!key.asString().equals(rs.getString("k"))) {
-        LOG.fatal("Read key: " + key.asString() + ", got " + rs.getString("k"));
-      }
-      LOG.debug("Read key: " + key.toString());
+        if (!key.asString().equals(rs.getString("k"))) {
+          LOG.error("Read key: " + key.asString() + ", got " + rs.getString("k"));
+        }
+        LOG.debug("Read key: " + key.toString());
 
-      if (rs.next()) {
-        LOG.fatal("Read key: " + key.asString() +
-            " expected 1 row in result, got more than one");
-        return 0;
+        if (rs.next()) {
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got more");
+          return 0;
+        }
       }
     } catch (Exception e) {
       LOG.fatal("Failed reading value: " + key.getValueStr(), e);
@@ -139,12 +137,12 @@ public class SqlSnapshotTxns extends AppBase {
   }
 
   private PreparedStatement getPreparedInsert() throws Exception {
-    String stmt = "BEGIN ISOLATION LEVEL SNAPSHOT;" + 
+    String stmt = "BEGIN TRANSACTION;" +
                   String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()) +
                   String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()) +
                   "COMMIT;";
     if (preparedInsert == null) {
-      preparedInsert = getPostgresConnection(postgres_ybdemo_database).prepareStatement(stmt);
+      preparedInsert = getPostgresConnection().prepareStatement(stmt);
     }
     return preparedInsert;
   }
@@ -188,7 +186,7 @@ public class SqlSnapshotTxns extends AppBase {
   }
 
   @Override
-  public List<String> getExampleUsageOptions() {
+  public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -758,6 +758,7 @@ public class CmdLineOpts {
       int port = 0;
       if (workloadType.toString().startsWith("Cassandra")) port = 9042;
       else if (workloadType.toString().startsWith("Redis")) port = 6379;
+      else if (workloadType.toString().startsWith("Sql")) port = 5433;
       AppBase workload = getAppClass(workloadType).newInstance();
 
       footer.append("\n - " + workloadType.toString() + " :\n");
@@ -783,10 +784,15 @@ public class CmdLineOpts {
       footer.append(optsPrefix + "--workload " + workloadType.toString() + optsSuffix);
       footer.append(optsPrefix + "--nodes 127.0.0.1:" + port);
 
-      List<String> usageOptions = workload.getExampleUsageOptions();
-      if (!usageOptions.isEmpty()) {
+      List<String> requiredArgs = workload.getWorkloadRequiredArguments();
+      for (String line : requiredArgs) {
+        footer.append(optsSuffix).append(optsPrefix).append(line);
+      }
+
+      List<String> optionalArgs = workload.getWorkloadOptionalArguments();
+      if (!optionalArgs.isEmpty()) {
         footer.append("\n\n\t\tOther options (with default values):\n");
-        for (String line : usageOptions) {
+        for (String line : optionalArgs) {
           footer.append(optsPrefix + "[ ");
           footer.append(line);
           footer.append(" ]\n");

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -166,7 +166,7 @@ public class SimpleLoadGenerator {
       if (retKey == null) {
         try {
           Thread.sleep(1 /* millisecs */);
-        } catch (InterruptedException e) { /*Ignore */ }
+        } catch (InterruptedException e) { /* Ignore */ }
       }
     } while (retKey == null);
 


### PR DESCRIPTION
General, all apps are now idempotent (i.e. can be run multiple times and will clean up output of old runs before starting).
`SqlInserts`: Enable bind variables for reads.
`SqlUpdates`: Now requires SqlInserts to run first, will then update those keys. Added new required arguments and updated help doc accordingly. 
`SqlSecondaryIndex` and `SqlSnapshotTxns`: Fix some syntax issues and update default args. 