### PR TITLE
Summary:

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -46,6 +46,7 @@ import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.datastax.driver.core.policies.LoggingRetryPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.yugabyte.driver.core.policies.PartitionAwarePolicy;
 import com.yugabyte.sample.common.CmdLineOpts;
 import com.yugabyte.sample.common.CmdLineOpts.ContactPoint;
@@ -210,13 +211,16 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   }
 
   protected LoadBalancingPolicy getLoadBalancingPolicy() {
-    DCAwareRoundRobinPolicy.Builder builder = DCAwareRoundRobinPolicy.builder();
+    LoadBalancingPolicy policy;
     if (appConfig.localDc != null && !appConfig.localDc.isEmpty()) {
-      builder.withLocalDc(appConfig.localDc)
-             .withUsedHostsPerRemoteDc(Integer.MAX_VALUE)
-             .allowRemoteDCsForLocalConsistencyLevel();
+      policy = DCAwareRoundRobinPolicy.builder()
+                                      .withUsedHostsPerRemoteDc(Integer.MAX_VALUE)
+                                      .withLocalDc(appConfig.localDc)
+                                      .allowRemoteDCsForLocalConsistencyLevel()
+                                      .build();
+    } else {
+      policy = new RoundRobinPolicy();
     }
-    LoadBalancingPolicy policy = builder.build();
     if (!appConfig.disableYBLoadBalancingPolicy) {
       policy = new PartitionAwarePolicy(policy);
     }


### PR DESCRIPTION
YCQL sample applications currently instantiate DCAwareRoundRobinPolicy without setting
UsedHostsPerRemoteDc when the local database center is not specified --with_local_dc.
This leaves the setting to default to 0 and only hosts from the local dc (which defaults to
the dc of the first host discovered) will be used which may not be the leader.

Instead, we should instantiate DCAwareRoundRobinPolicy only when --with_local_dc is set. Otherwise, we should use the plain RoundRobinPolicy.

Test Plan:
Run CassandraUniqueSecondaryIndex sample application in a multi-dc cluster and verify
all reads always are served by the leader.

Reviewers: sergei, bogdan, kannan

Reviewed By: kannan

Subscribers: kannan, yql

Differential Revision: https://phabricator.dev.yugabyte.com/D6300