### PR TITLE
Add SSL support for YCQL connections.

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -42,7 +42,7 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.QueryOptions;
 import com.datastax.driver.core.SimpleStatement;
 import com.datastax.driver.core.SSLOptions;
-import com.datastax.driver.core.NettySSLOptions;
+import com.datastax.driver.core.JdkSSLOptions;
 import com.datastax.driver.core.exceptions.NoHostAvailableException;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.DefaultRetryPolicy;
@@ -179,15 +179,15 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
    * Private function that returns an SSL Handler when provided with a cert file.
    * Used for creating a secure connection for the app.
    */
-  private SslHandler createSslHandler(String certfile) {
+  private SSLOptions createSSLHandler(String certfile) {
     try {
       CertificateFactory cf = CertificateFactory.getInstance("X.509");
-      FileInputStream fis = new FileInputStream(certFile);
+      FileInputStream fis = new FileInputStream(certfile);
       X509Certificate ca;
       try {
         ca = (X509Certificate) cf.generateCertificate(fis);
       } catch (Exception e) {
-        log.error("Exception generating certificate from input file: ", e);
+        LOG.error("Exception generating certificate from input file: ", e);
         return null;
       } finally {
         fis.close();
@@ -206,9 +206,9 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
 
       SSLContext sslContext = SSLContext.getInstance("TLS");
       sslContext.init(null, tmf.getTrustManagers(), null);
-      return new NettySSLOptions(sslContext);
+      return JdkSSLOptions.builder().withSSLContext(sslContext).build();
     } catch (Exception e) {
-      log.error("Exception creating sslContext: ", e);
+      LOG.error("Exception creating sslContext: ", e);
       return null;
     }
   }

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -162,4 +162,7 @@ public class AppConfig {
 
   // The number of client connections to establish to each host in the YugaByte DB cluster.
   public int concurrentClients = 4;
+
+  // The path to the certificate to be used for the SSL connection.
+  public String sslCert = null;
 }

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -288,6 +288,9 @@ public class CmdLineOpts {
       AppBase.appConfig.concurrentClients = Integer.parseInt(
           commandLine.getOptionValue("concurrent_clients"));
     }
+    if (commandLine.hasOption("ssl_cert")) {
+      AppBase.appConfig.sslCert = commandLine.getOptionValue("ssl_cert");
+    }
   }
 
   /**
@@ -546,6 +549,8 @@ public class CmdLineOpts {
             "If this option is set, yql_username option should be used too.");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
+    options.addOption("ssl_cert", true, 
+      "Use an SSL connection while connecting to YugaByte.")
 
     // Options for CassandraTimeseries workload.
     options.addOption("num_users", true, "[CassandraTimeseries] The total number of users.");

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -550,7 +550,7 @@ public class CmdLineOpts {
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true, 
-      "Use an SSL connection while connecting to YugaByte.")
+      "Use an SSL connection while connecting to YugaByte.");
 
     // Options for CassandraTimeseries workload.
     options.addOption("num_users", true, "[CassandraTimeseries] The total number of users.");


### PR DESCRIPTION
With YB universes not supporting insecure connections any more, the sample apps need to allow SSL connections to the cassandra query client.
Tested by running a sample app targeted to a universe with the following command:
```java -jar target/yb-sample-apps.jar --workload CassandraKeyValue --nodes 172.151.38.166:9042 --ssl_cert /opt/yugaware/certs/f33e3c9b-75ab-4c30-80ad-cba85646ea39/91ebf773-647d-4ba9-8736-7f077fefb681/ca.root.crt```
Also verified that is failed when no cert was provided.
Addressed issue: https://github.com/YugaByte/yugabyte-db/issues/1061