### PR TITLE
Increase the defaults for num_metrics in CassandraBatchTimeseries

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
@@ -64,9 +64,9 @@ public class CassandraBatchTimeseries extends AppBase {
   // The structure to hold info per metric.
   static List<DataSource> dataSources = new CopyOnWriteArrayList<DataSource>();
   // The minimum number of metrics to simulate.
-  private static int min_metrics_count = 5;
+  private static int min_metrics_count = 5000;
   // The maximum number of metrics to simulate.
-  private static int max_metrics_count = 10;
+  private static int max_metrics_count = 10000;
   // The shared prepared select statement for fetching the data.
   private static volatile PreparedStatement preparedSelect;
   // The shared prepared statement for inserting into the table.


### PR DESCRIPTION
The default setting for CassandraBatchTimeseries only creates 10 metrics, which causes a huge skew in the tablet sizes, unless one specifies `--min_metrics_count 10000 --max_metrics_count 20000`

Bumping up the defaults so that we create 10000 metrics by default. Unless overridden by commandline flags.