### PR TITLE
Set default YSQL database/user to "yugabyte"

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -117,10 +117,10 @@ public class AppConfig {
   public String tableName = null;
 
   // Name of the default database for postgres.
-  public String defaultPostgresDatabase = "postgres";
+  public String defaultPostgresDatabase = "yugabyte";
 
   // Name of the default username for postgres.
-  public String defaultPostgresUsername = "postgres";
+  public String defaultPostgresUsername = "yugabyte";
 
   // Does the table need to be dropped.
   public boolean shouldDropTable = false;


### PR DESCRIPTION
Since our default database and user have changed to `yugabyte`, this should be reflected in sample apps as well.