### PR TITLE
Add SqlDataLoad sample app

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -84,8 +84,8 @@ public class AppConfig {
   // Batch size to send from client for redis pipeline app.
   public int redisPipelineLength = 1;
 
-  // Batch size to send from client for Cassandra batch key-value app.
-  public int cassandraBatchSize = 1;
+  // Batch size for apps that support batching.
+  public int batchSize = 1;
 
   // Batch size to read for Cassandra batch timeseries app.
   public int cassandraReadBatchSize = 1;
@@ -173,5 +173,11 @@ public class AppConfig {
   // Number of Event Types per device to simulate data for CassandraEventData workload
   public int num_event_types = 100;
 
+  // Configurations for SqlDataLoad workload.
+  public int numValueColumns = 1;
+  public int numIndexes = 0;
+  public int numForeignKeys = 0;
+  public int numForeignKeyTableRows = 1000; // Only relevant if num_foreign_keys > 0.
+  public int numConsecutiveRowsWithSameFk = 500; // Only relevant if num_foreign_keys > 0.
 
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
@@ -35,14 +35,14 @@ public class CassandraBatchKeyValue extends CassandraKeyValue {
   // Static initialization of this workload's config.
   static {
     // The number of keys to write in each batch.
-    appConfig.cassandraBatchSize = 10;
+    appConfig.batchSize = 10;
   }
 
   // Buffers for each key in a batch.
   private final byte[][] buffers;
 
   public CassandraBatchKeyValue() {
-    buffers = new byte[appConfig.cassandraBatchSize][appConfig.valueSize];
+    buffers = new byte[appConfig.batchSize][appConfig.valueSize];
   }
 
   @Override
@@ -51,7 +51,7 @@ public class CassandraBatchKeyValue extends CassandraKeyValue {
     HashSet<Key> keys = new HashSet<Key>();
     PreparedStatement insert = getPreparedInsert();
     try {
-      for (int i = 0; i < appConfig.cassandraBatchSize; i++) {
+      for (int i = 0; i < appConfig.batchSize; i++) {
         Key key = getSimpleLoadGenerator().getKeyToWrite();
         ByteBuffer value = null;
         if (appConfig.valueSize == 0) {
@@ -95,7 +95,7 @@ public class CassandraBatchKeyValue extends CassandraKeyValue {
       "--value_size " + appConfig.valueSize,
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,
-      "--batch_size " + appConfig.cassandraBatchSize,
+      "--batch_size " + appConfig.batchSize,
       "--table_ttl_seconds " + appConfig.tableTTLSeconds);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
@@ -51,7 +51,7 @@ public class CassandraBatchTimeseries extends AppBase {
     // Set the TTL for the raw table.
     appConfig.tableTTLSeconds = 24 * 60 * 60;
     // Default write batch size.
-    appConfig.cassandraBatchSize = 500;
+    appConfig.batchSize = 500;
     // Default read batch size.
     appConfig.cassandraReadBatchSize = 100;
     // Default time delta from current time to read in a batch.
@@ -220,7 +220,7 @@ public class CassandraBatchTimeseries extends AppBase {
     BatchStatement batch = new BatchStatement();
     // Enter a batch of data points.
     long ts = dataSource.getDataEmitTs();
-    for (int i = 0; i < appConfig.cassandraBatchSize; i++) {
+    for (int i = 0; i < appConfig.batchSize; i++) {
       batch.add(getPreparedInsert().bind().setString("metric_id", dataSource.getMetricId())
                                           .setLong("ts", ts)
                                           .setString("value", getValue(ts)));
@@ -307,7 +307,7 @@ public class CassandraBatchTimeseries extends AppBase {
       "--num_threads_write " + appConfig.numWriterThreads,
       "--max_metrics_count " + max_metrics_count,
       "--table_ttl_seconds " + appConfig.tableTTLSeconds,
-      "--batch_size " + appConfig.cassandraBatchSize,
+      "--batch_size " + appConfig.batchSize,
       "--read_batch_size " + appConfig.cassandraReadBatchSize);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
@@ -14,13 +14,11 @@
 package com.yugabyte.sample.apps;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import org.apache.commons.cli.CommandLine;
 import org.apache.log4j.Logger;
 
 import com.datastax.driver.core.BatchStatement;
@@ -29,7 +27,6 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.ResultSet;
 
 import com.yugabyte.sample.common.CmdLineOpts;
-import com.datastax.driver.core.utils.Bytes;
 
 /**
  * A sample IoT event data application with batch processing
@@ -55,7 +52,7 @@ public class CassandraEventData extends AppBase {
 		// Set the TTL for the raw table.
 		appConfig.tableTTLSeconds = 24 * 60 * 60;
 		// Default write batch size.
-		appConfig.cassandraBatchSize = 25;
+		appConfig.batchSize = 25;
 		// Default read batch size.
 		appConfig.cassandraReadBatchSize = 25;
 		// Default time delta from current time to read in a batch.
@@ -204,7 +201,7 @@ public class CassandraEventData extends AppBase {
 		BatchStatement batch = new BatchStatement();
 		// Enter a batch of data points.
 		long ts = dataSource.getDataEmitTs();
-		for (int i = 0; i < appConfig.cassandraBatchSize; i++) {
+		for (int i = 0; i < appConfig.batchSize; i++) {
 			batch.add(getPreparedInsert().bind().setString("device_id", dataSource.getDeviceId()).setLong("ts", ts)
 					.setString("event_type", dataSource.getEventType())
 					.setBytesUnsafe("value", getValue(dataSource.getDeviceId())));
@@ -295,7 +292,7 @@ public class CassandraEventData extends AppBase {
 		return Arrays.asList("--num_threads_read " + appConfig.numReaderThreads,
 				"--num_threads_write " + appConfig.numWriterThreads, "--num_devices " + appConfig.num_devices,
 				"--num_event_types " + appConfig.num_event_types, "--table_ttl_seconds " + appConfig.tableTTLSeconds,
-				"--batch_size " + appConfig.cassandraBatchSize,
+				"--batch_size " + appConfig.batchSize,
 				"--read_batch_size " + appConfig.cassandraReadBatchSize);
 	}
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
@@ -116,7 +116,7 @@ public class CassandraSecondaryIndex extends CassandraKeyValue {
       if (appConfig.batchWrite) {
         BatchStatement batch = new BatchStatement();
         PreparedStatement insert = getPreparedInsert();
-        for (int i = 0; i < appConfig.cassandraBatchSize; i++) {
+        for (int i = 0; i < appConfig.batchSize; i++) {
           Key key = getSimpleLoadGenerator().getKeyToWrite();
           keys.add(key);
           batch.add(insert.bind(key.asString(), key.getValueStr()));
@@ -168,6 +168,6 @@ public class CassandraSecondaryIndex extends CassandraKeyValue {
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,
       "--batch_write",
-      "--batch_size " + appConfig.cassandraBatchSize);
+      "--batch_size " + appConfig.batchSize);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -1,0 +1,305 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+package com.yugabyte.sample.apps;
+
+import java.sql.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
+
+/**
+ * This workload sets up from a YSQL table with user-given number of secondary indexes and/or
+ * foreign key constraints.
+ * Then runs a write workload to load data into the target table.
+ */
+public class SqlDataLoad extends AppBase {
+    private static final Logger LOG = Logger.getLogger(SqlInserts.class);
+
+    // Static initialization of this workload's config. These are good defaults for getting a decent
+    // read dominated workload on a reasonably powered machine. Exact IOPS will of course vary
+    // depending on the machine and what resources it has to spare.
+    static {
+        // Disable the read-write percentage.
+        appConfig.readIOPSPercentage = -1;
+        // Disable reads for this workload.
+        appConfig.numReaderThreads = 0;
+
+        // Set the write thread to 2 by default.
+        appConfig.numWriterThreads = 2;
+        // The number of keys to read.
+        appConfig.numKeysToRead = -1;
+        // The number of keys to write.
+        appConfig.numKeysToWrite = -1;
+        // When to switch from inserts to updates -- in this workload never by default.
+        appConfig.numUniqueKeysToWrite = -1;
+    }
+
+    // The default table name to create and use for CRUD ops.
+    private static final String DEFAULT_TABLE_NAME = "SqlDataLoad";
+
+    // The prepared select statement for fetching the data.
+    private PreparedStatement preparedSelect = null;
+
+    // The prepared insert statement for inserting the data.
+    private PreparedStatement preparedInsert = null;
+
+    // Lock for initializing prepared statement objects.
+    private static final Object prepareInitLock = new Object();
+
+    public SqlDataLoad() {
+        buffer = new byte[appConfig.valueSize];
+    }
+
+    /**
+     * Drop the table created by this app.
+     */
+    @Override
+    public void dropTable() throws Exception {
+        Connection connection = getPostgresConnection();
+        connection.createStatement().execute("DROP TABLE " + getTableName());
+        LOG.info(String.format("Dropped table: %s", getTableName()));
+        for (int i = 1; i <= appConfig.numForeignKeys; i++) {
+            String fkName = getFkTableName(i);
+            connection.createStatement().execute(String.format("DROP TABLE IF EXISTS %s CASCADE", fkName));
+        }
+    }
+
+    private String getFkTableName(int idx) {
+        return String.format("%s_fk_%d", getTableName(), idx);
+    }
+
+    @Override
+    public void createTablesIfNeeded() throws Exception {
+        try (Connection connection = getPostgresConnection();
+             Statement statement = connection.createStatement()) {
+
+            statement.execute(
+                    String.format("DROP TABLE IF EXISTS %s CASCADE", getTableName()));
+            LOG.info("Dropped table(s) left from previous runs if any");
+
+            // Initialize foreign key tables (if any) -- create tables and load sample data.
+            for (int i = 1; i <= appConfig.numForeignKeys; i++) {
+                String fkName = getFkTableName(i);
+
+                statement.execute(String.format("DROP TABLE IF EXISTS %s CASCADE", fkName));
+
+                statement.execute(String.format("CREATE TABLE %s (k varchar PRIMARY KEY)", fkName));
+
+                String fkInsert = String.format("INSERT INTO %s (k) VALUES (?)", fkName);
+                PreparedStatement preparedFkInsert = connection.prepareStatement(fkInsert);
+
+                for (int j = 1; j <= appConfig.numForeignKeyTableRows; j++) {
+                    preparedFkInsert.setString(1, String.valueOf(j));
+                    preparedFkInsert.executeUpdate();
+                }
+            }
+
+            if (appConfig.numForeignKeys > 0) {
+                LOG.info(String.format("Initialized %d foreign-key tables",
+                                       appConfig.numForeignKeys));
+            }
+
+            // Create main table.
+            StringBuilder sb = new StringBuilder();
+            sb.append("CREATE TABLE ");
+            sb.append(getTableName());
+            sb.append(" (k varchar PRIMARY KEY");
+
+            for (int i = 1; i <= appConfig.numValueColumns; i++) {
+                String cname = "v" + i;
+                sb.append(", ").append(cname).append(" varchar");
+
+                if (i <= appConfig.numForeignKeys) {
+                    sb.append(" REFERENCES ").append(getFkTableName(i));
+                }
+
+            }
+
+            sb.append(")");
+            statement.execute(sb.toString());
+            LOG.info(String.format("Created table: %s", getTableName()));
+
+            // Create secondary indexes (if any).
+            for (int i = 0; i < appConfig.numIndexes; i++) {
+                int colidx = i % appConfig.numValueColumns + 1;
+                String cname = "v" + colidx;
+                String idx_stmt = String.format("CREATE INDEX %sByValue%s_idx%d ON %s (%s)",
+                                                getTableName(),
+                                                cname,
+                                                i,
+                                                getTableName(),
+                                                cname);
+                statement.execute(idx_stmt);
+            }
+
+            if (appConfig.numIndexes > 0) {
+                LOG.info(String.format("Created %d secondary indexes",
+                                       appConfig.numIndexes));
+            }
+        }
+    }
+
+    public String getTableName() {
+        String tableName = appConfig.tableName != null ? appConfig.tableName : DEFAULT_TABLE_NAME;
+        return tableName.toLowerCase();
+    }
+
+    private PreparedStatement getPreparedSelect() throws Exception {
+        if (preparedSelect == null) {
+            preparedSelect = getPostgresConnection().prepareStatement(
+                    String.format("SELECT k, v FROM %s WHERE k = ?;", getTableName()));
+        }
+        return preparedSelect;
+    }
+
+    @Override
+    public long doRead() {
+        Key key = getSimpleLoadGenerator().getKeyToRead();
+        if (key == null) {
+            // There are no keys to read yet.
+            return 0;
+        }
+
+        try {
+            PreparedStatement statement = getPreparedSelect();
+            statement.setString(1, key.asString());
+            try (ResultSet rs = statement.executeQuery()) {
+                if (!rs.next()) {
+                    LOG.error("Read key: " + key.asString() + " expected 1 row in result, got 0");
+                    return 0;
+                }
+
+                if (!key.asString().equals(rs.getString("k"))) {
+                    LOG.error("Read key: " + key.asString() + ", got " + rs.getString("k"));
+                }
+                LOG.debug("Read key: " + key.toString());
+
+                if (rs.next()) {
+                    LOG.error("Read key: " + key.asString() + " expected 1 row in result, got more");
+                    return 0;
+                }
+            }
+        } catch (Exception e) {
+            LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+            return 0;
+        }
+        return 1;
+    }
+
+    private PreparedStatement getPreparedInsert() throws Exception {
+        if (preparedInsert == null) {
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("INSERT INTO ").append(getTableName()).append("(k");
+            for (int i = 0; i < appConfig.numValueColumns; i++) {
+                String cname = "v" + (i + 1);
+                sb.append(", ").append(cname);
+            }
+            sb.append(") VALUES ( ?");
+            for (int i = 0; i < appConfig.numValueColumns; i++) {
+                sb.append(", ?");
+            }
+            sb.append(")");
+
+            preparedInsert = getPostgresConnection().prepareStatement(sb.toString());
+        }
+        return preparedInsert;
+    }
+
+    private String getValue(Key key, int col_idx, long key_idx) {
+
+        if (col_idx <= appConfig.numForeignKeys) {
+            long block_idx = key_idx / appConfig.numConsecutiveRowsWithSameFk;
+            long fkey_idx = (block_idx % appConfig.numForeignKeyTableRows) +  1;
+            return String.valueOf(fkey_idx);
+        }
+
+        return key.getValueStr();
+    }
+
+    @Override
+    public long doWrite(int threadIdx) {
+        HashSet<Key> keys = new HashSet<>();
+
+        try {
+            PreparedStatement statement = getPreparedInsert();
+
+            if (appConfig.batchSize > 0) {
+                for (int i = 0; i < appConfig.batchSize; i++) {
+                    keys.add(setupParams(statement));
+                    statement.addBatch();
+                }
+                statement.executeBatch();
+            } else {
+                keys.add(setupParams(statement));
+                statement.execute();
+            }
+
+            for (Key key : keys) {
+                getSimpleLoadGenerator().recordWriteSuccess(key);
+            }
+            return keys.size();
+
+        } catch (Exception e) {
+            for (Key key : keys) {
+                getSimpleLoadGenerator().recordWriteFailure(key);
+            }
+            LOG.fatal("Failed write with error: " + e.getMessage());
+        }
+        return keys.size();
+    }
+
+
+    private Key setupParams(PreparedStatement statement) throws Exception {
+        Key key = getSimpleLoadGenerator().getKeyToWrite();
+        if (key == null) {
+            throw new IllegalStateException("Cannot write null key");
+        }
+
+        // Prefix hashcode to ensure generated keys are random and not sequential.
+        statement.setString(1, key.asString());
+
+        for (int i = 1; i <= appConfig.numValueColumns; i++) {
+            statement.setString(i + 1, getValue(key, i, key.asNumber()));
+        }
+
+        return key;
+    }
+
+
+    @Override
+    public List<String> getWorkloadDescription() {
+        return Arrays.asList(
+                "Sample app for benchmarking data load into Yugabyte SQL.",
+                "Inserts auto-generated rows into a table with various configurable settings: ",
+                "number of value columns, number of secondary indexes, number of foreign key ",
+                "constraints, batch size, number of write threads, etc.");
+    }
+
+    @Override
+    public List<String> getWorkloadOptionalArguments() {
+        return Arrays.asList(
+                "--num_writes " + appConfig.numKeysToWrite,
+                "--num_value_columns " + appConfig.numValueColumns,
+                "--num_indexes " + appConfig.numIndexes,
+                "--num_foreign_keys " + appConfig.numForeignKeys,
+                "--num_foreign_key_table_rows " + appConfig.numForeignKeyTableRows,
+                "--num_consecutive_rows_with_same_fk " + appConfig.numConsecutiveRowsWithSameFk,
+                "--batch_size " + appConfig.batchSize,
+                "--num_threads_write " + appConfig.numWriterThreads);
+    }
+}


### PR DESCRIPTION
Add SQLDataLoad as a configurable sample app for benchmarking data loading into an YSQL table.
It allows configuring the number of columns, indexes, foreign keys, write-threads, batch size, etc.
See `java -jar target/yb-sample-apps.jar --help SqlDataLoad` for more details.

Examples:
- Table with `100` columns, using batch size `10` (`16` write threads).
```
java -jar target/yb-sample-apps.jar --workload SqlDataLoad --nodes 127.0.0.1:5433 \ 
        --num_threads_write 16 --num_value_columns 100 --batch_size 10
```
- Table with `2` indexes and `1` foreign key (`8` write threads).
```
java -jar target/yb-sample-apps.jar --workload SqlDataLoad --nodes 127.0.0.1:5433 \
        --num_threads_write 8 --num_indexes 2  --num_foreign_keys 1 
```