### PR TITLE
Fix parsing of IPv6 contact points

### DIFF
--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -917,9 +917,12 @@ public class CmdLineOpts {
     }
 
     public static ContactPoint fromHostPort(String hostPort) {
-      String[] parts = hostPort.split(":");
-      String host = parts[0];
-      int port = Integer.parseInt(parts[1]);
+      int portSplit = hostPort.lastIndexOf(":");
+      if (portSplit < 0) {
+        throw new RuntimeException("Invalid port specification in " + hostPort);
+      }
+      String host = hostPort.substring(0, portSplit);
+      int port = Integer.parseInt(hostPort.substring(portSplit + 1));
       return new ContactPoint(host, port);
     }
 


### PR DESCRIPTION
Tested the following command lines to verify the parsing

`java -jar target/yb-sample-apps.jar --nodes foo5433 --workload SqlInserts`
(got exception)

`java -jar target/yb-sample-apps.jar --nodes [2600:1f18:1094:c832:36e6:43b9:e6c8:f02]:5433 --workload SqlInserts`
(works correctly and earlier did not work correctly)

and regular DNS, IPv4 addresses
(worked always)