### PR TITLE
Add flag to keep table at application launch

### DIFF
--- a/src/main/java/com/yugabyte/sample/Main.java
+++ b/src/main/java/com/yugabyte/sample/Main.java
@@ -164,7 +164,7 @@ public class Main {
         System.exit(0);
       }
 
-      app.createTablesIfNeeded();
+      app.createTablesIfNeeded(app.appConfig.tableOp);
 
       // For 100% read case, do a pre-setup to write a bunch of keys and enable metrics tracking
       // after that.

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -121,6 +121,12 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   // YCQL keyspace name.
   public static String keyspace = "ybdemo_keyspace";
 
+  public enum TableOp {
+    NoOp,
+    DropTable,
+    TruncateTable,
+  }
+
   //////////// Helper methods to return the client objects (Redis, Cassandra, etc). ////////////////
 
   /**
@@ -524,9 +530,10 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
 
   /**
    * The apps extending this base should create all the necessary tables in this method.
+   * @param tableOp operation on table, e.g. drop the table at beginning of application launch
    * @throws java.lang.Exception in case of CREATE statement errors.
    */
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     for (String create_stmt : getCreateTableStatements()) {
       Session session = getCassandraClient();
       // consistency level of one to allow cross DC requests.

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -13,6 +13,8 @@
 
 package com.yugabyte.sample.apps;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
+
 /**
  * This class encapsulates the various configuration parameters for the various apps.
  */
@@ -125,8 +127,8 @@ public class AppConfig {
   // Name of the default username for postgres.
   public String defaultPostgresUsername = "postgres";
 
-  // Does the table need to be dropped.
-  public boolean shouldDropTable = false;
+  // Should we drop / truncate table.
+  public AppBase.TableOp tableOp = TableOp.NoOp;
 
   // Skip running workloads. These might be operations independent of workload.
   // For example, if we only need to drop a table, or any such DDL/non-CRUD op.

--- a/src/main/java/com/yugabyte/sample/apps/MultiTableMultiIndexInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/MultiTableMultiIndexInserts.java
@@ -235,7 +235,8 @@ public class MultiTableMultiIndexInserts extends AppBase {
     LOG.info("Dropped all tables");
   }
 
-  public void createTablesIfNeeded() throws Exception {
+  @Override
+  public void createTablesIfNeeded(TableOp dropTable) throws Exception {
     dropTable();
     Connection connection = getPostgresConnection();
     Statement statement = connection.createStatement();

--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 /**
@@ -83,7 +84,7 @@ public class SqlDataLoad extends AppBase {
     }
 
     @Override
-    public void createTablesIfNeeded() throws Exception {
+    public void createTablesIfNeeded(TableOp tableOp) throws Exception {
         try (Connection connection = getPostgresConnection();
              Statement statement = connection.createStatement()) {
 

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import org.apache.log4j.Logger;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
@@ -91,7 +92,7 @@ public class SqlForeignKeysAndJoins extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     Connection connection = getPostgresConnection();
     connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
 

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 /**
@@ -73,16 +74,23 @@ public class SqlInserts extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     Connection connection = getPostgresConnection();
 
     // (Re)Create the table (every run should start cleanly with an empty table).
-    // connection.createStatement().execute(
-    //     String.format("DROP TABLE IF EXISTS %s", getTableName()));
-    LOG.info("Dropping any table(s) left from previous runs if any");
+    if (tableOp.equals(TableOp.DropTable)) {
+        connection.createStatement().execute(
+            String.format("DROP TABLE IF EXISTS %s", getTableName()));
+        LOG.info("Dropping any table(s) left from previous runs if any");
+    }
     connection.createStatement().execute(
         String.format("CREATE TABLE IF NOT EXISTS %s (k text PRIMARY KEY, v text)", getTableName()));
     LOG.info(String.format("Created table: %s", getTableName()));
+    if (tableOp.equals(TableOp.TruncateTable)) {
+    	connection.createStatement().execute(
+          String.format("TRUNCATE TABLE %s", getTableName()));
+      LOG.info(String.format("Truncated table: %s", getTableName()));
+    }
   }
 
   public String getTableName() {

--- a/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 /**
@@ -73,16 +74,24 @@ public class SqlSecondaryIndex extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     Connection connection = getPostgresConnection();
 
     // (Re)Create the table (every run should start cleanly with an empty table).
-    // connection.createStatement().execute(
-    //     String.format("DROP TABLE IF EXISTS %s", getTableName()));
-    LOG.info("Dropping table(s) left from previous runs if any");
+    if (tableOp.equals(TableOp.DropTable)) {
+        connection.createStatement().execute(
+            String.format("DROP TABLE IF EXISTS %s", getTableName()));
+        LOG.info("Dropping table(s) left from previous runs if any");
+    }
     connection.createStatement().executeUpdate(
         String.format("CREATE TABLE IF NOT EXISTS %s (k text PRIMARY KEY, v text);", getTableName()));
     LOG.info(String.format("Created table: %s", getTableName()));
+
+    if (tableOp.equals(TableOp.TruncateTable)) {
+    	connection.createStatement().execute(
+          String.format("TRUNCATE TABLE %s", getTableName()));
+      LOG.info(String.format("Truncated table: %s", getTableName()));
+    }
 
     // Create an index on the table.
     connection.createStatement().executeUpdate(

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.apache.log4j.Logger;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 import static java.sql.Connection.TRANSACTION_REPEATABLE_READ;
@@ -75,7 +76,7 @@ public class SqlSnapshotTxns extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     Connection connection = getPostgresConnection();
     connection.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
     connection.setAutoCommit(false);

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.CmdLineOpts;
 import org.apache.log4j.Logger;
 
@@ -66,7 +67,7 @@ public class SqlUpdates extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     // Check that (extra_ required options are set (maxWrittenKey and loadTesterUUID) set.
     if (appConfig.maxWrittenKey <= 0) {
       LOG.fatal("Workload requires option --max_written_key to be set. \n " +


### PR DESCRIPTION
Currently applications such as SqlInserts and SqlSecondaryIndex do not drop existing table in createTablesIfNeeded().

This PR changes the behavior where by default, the table would be truncated in createTablesIfNeeded().

A flag, keep_table (without argument), is added. When the flag is specified, the table would be kept (and not truncated).

This is to facilitate simultaneous runs of the same application against the same DB table.