### PR TITLE
Change default consistency level to QUORUM

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -275,7 +275,9 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
       cassandra_cluster =
           builder.withLoadBalancingPolicy(getLoadBalancingPolicy())
                  .withPoolingOptions(poolingOptions)
-                 .withQueryOptions(new QueryOptions().setDefaultIdempotence(true))
+                 .withQueryOptions(new QueryOptions()
+                     .setDefaultIdempotence(true)
+                     .setConsistencyLevel(ConsistencyLevel.QUORUM))
                  .withRetryPolicy(new LoggingRetryPolicy(DefaultRetryPolicy.INSTANCE))
                  .build();
       LOG.debug("Connected to cluster: " + cassandra_cluster.getClusterName());


### PR DESCRIPTION
The default consistency used by YugabyteDB is QUORUM (for reads and writes).

However, when this tool is used against say Apache Cassandra, where the default is ONE, then the comparison becomes apples to oranges. 

To avoid the confusion, just explicitly set the consistency level to QUORUM.