### PR TITLE
Add support of cert and key for YSQL

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -158,6 +158,12 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
     }
     props.setProperty("sslmode", "disable");
     props.put("reWriteBatchedInserts", "true");
+    if (appConfig.ysqlCert != null) {
+      props.put("sslcert", appConfig.ysqlCert);
+    }
+    if (appConfig.ysqlKey != null) {
+      props.put("sslkey", appConfig.ysqlKey);
+    }
     String connectStr = String.format("jdbc:postgresql://%s:%d/%s", contactPoint.getHost(),
                                                                     contactPoint.getPort(),
                                                                     database);
@@ -241,9 +247,9 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         builder = builder
             .withCredentials(appConfig.dbUsername, appConfig.dbPassword);
       }
-      if (appConfig.sslCert != null) {
+      if (appConfig.ycqlCert != null) {
         builder = builder
-            .withSSL(createSSLHandler(appConfig.sslCert));
+            .withSSL(createSSLHandler(appConfig.ycqlCert));
       }
       Integer port = null;
       SocketOptions socketOptions = new SocketOptions();

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -166,11 +166,17 @@ public class AppConfig {
   // Password to connect to the DB.
   public String dbPassword = null;
 
+  // The path to the certificate to be used for the SSL connection to Postgres.
+  public String ysqlCert = null;
+
+  // The path to the key to be used for the SSL connection to Postgres.
+  public String ysqlKey = null;
+
   // The number of client connections to establish to each host in the YugaByte DB cluster.
   public int concurrentClients = 4;
 
   // The path to the certificate to be used for the SSL connection.
-  public String sslCert = null;
+  public String ycqlCert = null;
   // Number of devices to simulate data for CassandraEventData workload
   public int num_devices = 100;
   // Number of Event Types per device to simulate data for CassandraEventData workload

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -313,6 +313,13 @@ public class CmdLineOpts {
     if (commandLine.hasOption("username")) {
       AppBase.appConfig.dbUsername = commandLine.getOptionValue("username");
     }
+    if (commandLine.hasOption("ysql_cert")) {
+      AppBase.appConfig.ysqlCert = commandLine.getOptionValue("ysql_cert");
+    }
+    if (commandLine.hasOption("ysql_key")) {
+      AppBase.appConfig.ysqlKey = commandLine.getOptionValue("ysql_Key");
+    }
+    
     if (commandLine.hasOption("password")) {
       if (!commandLine.hasOption("username")) {
         LOG.error("--password requires --username to be set");
@@ -324,8 +331,8 @@ public class CmdLineOpts {
       AppBase.appConfig.concurrentClients = Integer.parseInt(
           commandLine.getOptionValue("concurrent_clients"));
     }
-    if (commandLine.hasOption("ssl_cert")) {
-      AppBase.appConfig.sslCert = commandLine.getOptionValue("ssl_cert");
+    if (commandLine.hasOption("ycql_cert")) {
+      AppBase.appConfig.ycqlCert = commandLine.getOptionValue("ycql_cert");
     }
 
     if (commandLine.hasOption("num_indexes")) {
@@ -637,8 +644,12 @@ public class CmdLineOpts {
             "If this option is set, the --username option is required.");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
-    options.addOption("ssl_cert", true,
-      "Use an SSL connection while connecting to YugaByte.");
+    options.addOption("ycql_cert", true,
+        "Use an SSL connection while connecting to YugaByte.");
+    options.addOption("ysql_cert", true,
+        "Path to the certificate file for SSL connection while connecting to YugaByte Postgres Database.");
+    options.addOption("ysql_key", true,
+        "Path to the key file for SSL connection while connecting to YugaByte Postgres Database.");
     options.addOption("batch_size", true,
                       "Number of keys to write in a batch (for apps that support batching).");
 


### PR DESCRIPTION
This fixes https://github.com/yugabyte/yugabyte-db/issues/5599

1. ssl_cert is renamed to ycql_cert for YCQL connections
2. two new flags called ysql_cert and ysql_key are added for SSL connection to YSQL.