### PR TITLE
Adding SqlUpdatesWithProcedures

### DIFF
--- a/src/main/java/com/yugabyte/sample/Main.java
+++ b/src/main/java/com/yugabyte/sample/Main.java
@@ -166,6 +166,8 @@ public class Main {
 
       app.createTablesIfNeeded();
 
+      app.createStoredProcedures();
+
       // For 100% read case, do a pre-setup to write a bunch of keys and enable metrics tracking
       // after that.
       if (!cmdLineOpts.getReadOnly() && cmdLineOpts.getNumWriterThreads() == 0) {

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -543,6 +543,12 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   }
 
   /**
+   * The apps extending this base should create any stored procedures when this method is called.
+   * @throws java.lang.Exception in case of CREATE PROCEDURE statement errors.
+   */
+  public void createStoredProcedures() throws Exception {}
+
+  /**
    * Returns the redis server that we are currently talking to.
    * Used for debug purposes. Returns "" for non-redis workloads.
    * @return String format of redis server that we are talking t.

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -183,4 +183,7 @@ public class AppConfig {
   public int numForeignKeyTableRows = 1000; // Only relevant if num_foreign_keys > 0.
   public int numConsecutiveRowsWithSameFk = 500; // Only relevant if num_foreign_keys > 0.
 
+  // Configurations for SqlUpdatesWithProcedures workload.
+  public int updateBatchSize = 10;
+  public String storedProcedureName = "TestProc";
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -142,9 +142,6 @@ public class SqlUpdates extends AppBase {
       LOG.fatal("Failed reading value: " + key.getValueStr(), e);
       return 0;
     }
-
-    // Mark this key as completed.
-    getSimpleLoadGenerator().addCompletedKey(key);
     return 1;
   }
 

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -70,12 +70,12 @@ public class SqlUpdatesWithProcedures extends AppBase {
     // Check that (extra_ required options are set (maxWrittenKey and loadTesterUUID) set.
     if (appConfig.maxWrittenKey <= 0) {
       LOG.fatal("Workload requires option --max_written_key to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
+                "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
     if (CmdLineOpts.loadTesterUUID == null) {
       LOG.fatal("Workload requires option --uuid to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
+                "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
 
@@ -87,7 +87,7 @@ public class SqlUpdatesWithProcedures extends AppBase {
     if (!tables.next()) {
       LOG.fatal(
           String.format("Could not find the %s table. Did you run SqlInserts first?" +
-                            "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details",
+                        "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details",
                         getTableName()));
       System.exit(1);
     }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -235,7 +235,7 @@ public class SqlUpdatesWithProcedures extends AppBase {
     return Arrays.asList(
         "Sample key-value app built on PostgreSQL with concurrent readers and writers. ",
         "Similar to the SqlUpdates workload, except that this workload uses SQL procedures",
-        "to batch update statements together.",
+        "to batch update statements together, and does not repeat updates to the same key.",
         "The app updates existing string keys loaded by a run of the SqlInserts sample app.",
         "There are multiple readers and writers that update these keys and read them",
         "indefinitely, with the readers query the keys by the associated values that are",

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -368,6 +368,17 @@ public class CmdLineOpts {
                              AppBase.appConfig.numConsecutiveRowsWithSameFk));
     }
 
+    if (appName.equals(SqlUpdatesWithProcedures.class.getSimpleName())) {
+      if (commandLine.hasOption("update_batch_size")) {
+        AppBase.appConfig.updateBatchSize =
+                Integer.parseInt(commandLine.getOptionValue("update_batch_size"));
+      }
+
+      if (commandLine.hasOption("stored_procedure_name")) {
+        AppBase.appConfig.storedProcedureName = commandLine.getOptionValue("stored_procedure_name");
+      }
+    }
+
   }
 
   /**
@@ -751,6 +762,13 @@ public class CmdLineOpts {
 
     options.addOption("num_consecutive_rows_with_same_fk", true,
                       "[SqlDataLoad] Number of secondary indexes on the target table.");
+
+    // Options for SqlUpdatesWithProcedures.
+    options.addOption("update_batch_size", true,
+                      "[SqlUpdatesWithProcedures] Number of updates per procedure call.");
+
+    options.addOption("stored_procedure_name", true,
+                      "[SqlUpdatesWithProcedures] Name of stored procedure call to create and use.");
 
     // First check if a "--help" argument is passed with a simple parser. Note that if we add
     // required args, then the help string would not work. See:

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -208,7 +208,7 @@ public class SimpleLoadGenerator {
     return retKey;
   }
 
-  public Key getKey(KeyComparator kc, int maxAttempts) {
+  public Key getKey(KeyComparator kc, long maxAttempts) {
     long maxKey = maxWrittenKey.get();
     if (maxKey < 0) {
       return null;
@@ -231,7 +231,7 @@ public class SimpleLoadGenerator {
 
   public Key getKeyToUpdate() {
     // Find a unupdated key that has not failed or been updated yet.
-    Key key = getKey((k) -> (!failedKeys.contains(k) && !updatedKeys.contains(k)), 100);
+    Key key = getKey((k) -> (!failedKeys.contains(k) && !updatedKeys.contains(k)), maxWrittenKey.get());
     if (key != null && updatedKeys.add(key.asNumber())) {
       return key;
     }
@@ -241,7 +241,7 @@ public class SimpleLoadGenerator {
 
   public Key getUpdatedKeyToRead() {
     // Find a key that has not failed and that has been updated.
-    return getKey((key) -> (!failedKeys.contains(key) && updatedKeys.contains(key)), 100);
+    return getKey((key) -> (!failedKeys.contains(key) && updatedKeys.contains(key)), maxWrittenKey.get());
   }
 
   public long getMaxWrittenKey() {

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -98,7 +98,7 @@ public class SimpleLoadGenerator {
   final Set<Long> failedKeys;
   // Keys that have been written above maxWrittenKey.
   final Set<Long> writtenKeys;
-  // Keys that have been updated.
+  // Keys that have been updated, currently only used for SqlUpdatesWithProcedures.
   final Set<Long> updatedKeys;
   // A background thread to track keys written and increment maxWrittenKey.
   Thread writtenKeysTracker;

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -96,6 +96,8 @@ public class SimpleLoadGenerator {
   final Set<Long> failedKeys;
   // Keys that have been written above maxWrittenKey.
   final Set<Long> writtenKeys;
+  // Keys that have been written to and read, currently just used for Updates.
+  final Set<Long> completedKeys;
   // A background thread to track keys written and increment maxWrittenKey.
   Thread writtenKeysTracker;
   // The prefix for the key.
@@ -111,6 +113,7 @@ public class SimpleLoadGenerator {
     this.maxGeneratedKey = new AtomicLong(maxWrittenKey);
     failedKeys = new HashSet<Long>();
     writtenKeys = new HashSet<Long>();
+    completedKeys = new HashSet<Long>();
     writtenKeysTracker = new Thread("Written Keys Tracker") {
         @Override
         public void run() {
@@ -163,6 +166,12 @@ public class SimpleLoadGenerator {
     }
   }
 
+  public void addCompletedKey(Key key) {
+    if (key != null) {
+      completedKeys.add(key.asNumber());
+    }
+  }
+
   // Always returns a non-null key.
   public Key getKeyToWrite() {
     Key retKey = null;
@@ -194,7 +203,7 @@ public class SimpleLoadGenerator {
     }
     do {
       long key = ThreadLocalRandom.current().nextLong(maxKey);
-      if (!failedKeys.contains(key))
+      if (!failedKeys.contains(key) && !completedKeys.contains(key))
         return generateKey(key);
     } while (true);
   }


### PR DESCRIPTION
Adding a new workload that is similar to `SqlUpdates` but that uses sql procedures in order to batch the updates together (see batching of updates in https://github.com/yugabyte/yugabyte-db/issues/5257).