### PR TITLE
Re-adding SqlUpdatesWithProcedures (with build fixes)

### DIFF
--- a/src/main/java/com/yugabyte/sample/Main.java
+++ b/src/main/java/com/yugabyte/sample/Main.java
@@ -166,6 +166,8 @@ public class Main {
 
       app.createTablesIfNeeded(app.appConfig.tableOp);
 
+      app.createStoredProcedures();
+
       // For 100% read case, do a pre-setup to write a bunch of keys and enable metrics tracking
       // after that.
       if (!cmdLineOpts.getReadOnly() && cmdLineOpts.getNumWriterThreads() == 0) {

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -549,6 +549,12 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   }
 
   /**
+   * The apps extending this base should create any stored procedures when this method is called.
+   * @throws java.lang.Exception in case of CREATE PROCEDURE statement errors.
+   */
+  public void createStoredProcedures() throws Exception {}
+
+  /**
    * Returns the redis server that we are currently talking to.
    * Used for debug purposes. Returns "" for non-redis workloads.
    * @return String format of redis server that we are talking t.

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -185,4 +185,7 @@ public class AppConfig {
   public int numForeignKeyTableRows = 1000; // Only relevant if num_foreign_keys > 0.
   public int numConsecutiveRowsWithSameFk = 500; // Only relevant if num_foreign_keys > 0.
 
+  // Configurations for SqlUpdatesWithProcedures workload.
+  public int updateBatchSize = 10;
+  public String storedProcedureName = "TestProc";
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -143,9 +143,6 @@ public class SqlUpdates extends AppBase {
       LOG.fatal("Failed reading value: " + key.getValueStr(), e);
       return 0;
     }
-
-    // Mark this key as completed.
-    getSimpleLoadGenerator().addCompletedKey(key);
     return 1;
   }
 

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -70,12 +70,12 @@ public class SqlUpdatesWithProcedures extends AppBase {
     // Check that (extra_ required options are set (maxWrittenKey and loadTesterUUID) set.
     if (appConfig.maxWrittenKey <= 0) {
       LOG.fatal("Workload requires option --max_written_key to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
+                "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
     if (CmdLineOpts.loadTesterUUID == null) {
       LOG.fatal("Workload requires option --uuid to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
+                "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
 
@@ -87,7 +87,7 @@ public class SqlUpdatesWithProcedures extends AppBase {
     if (!tables.next()) {
       LOG.fatal(
           String.format("Could not find the %s table. Did you run SqlInserts first?" +
-                            "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details",
+                        "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details",
                         getTableName()));
       System.exit(1);
     }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -235,7 +235,7 @@ public class SqlUpdatesWithProcedures extends AppBase {
     return Arrays.asList(
         "Sample key-value app built on PostgreSQL with concurrent readers and writers. ",
         "Similar to the SqlUpdates workload, except that this workload uses SQL procedures",
-        "to batch update statements together.",
+        "to batch update statements together, and does not repeat updates to the same key.",
         "The app updates existing string keys loaded by a run of the SqlInserts sample app.",
         "There are multiple readers and writers that update these keys and read them",
         "indefinitely, with the readers query the keys by the associated values that are",

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -16,11 +16,10 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
-import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.CmdLineOpts;
 import org.apache.log4j.Logger;
 
@@ -29,8 +28,8 @@ import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 /**
  * This workload writes and reads some random string keys from a postgresql table.
  */
-public class SqlUpdates extends AppBase {
-  private static final Logger LOG = Logger.getLogger(SqlUpdates.class);
+public class SqlUpdatesWithProcedures extends AppBase {
+  private static final Logger LOG = Logger.getLogger(SqlUpdatesWithProcedures.class);
 
   // Static initialization of this workload's config. These are good defaults for getting a decent
   // read dominated workload on a reasonably powered machine. Exact IOPS will of course vary
@@ -62,21 +61,21 @@ public class SqlUpdates extends AppBase {
   // Lock for initializing prepared statement objects.
   private static final Object prepareInitLock = new Object();
 
-  public SqlUpdates() {
+  public SqlUpdatesWithProcedures() {
     buffer = new byte[appConfig.valueSize];
   }
 
   @Override
-  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
+  public void createTablesIfNeeded() throws Exception {
     // Check that (extra_ required options are set (maxWrittenKey and loadTesterUUID) set.
     if (appConfig.maxWrittenKey <= 0) {
       LOG.fatal("Workload requires option --max_written_key to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdates' for more details");
+                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
     if (CmdLineOpts.loadTesterUUID == null) {
       LOG.fatal("Workload requires option --uuid to be set. \n " +
-                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdates' for more details");
+                    "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details");
       System.exit(1);
     }
 
@@ -88,7 +87,7 @@ public class SqlUpdates extends AppBase {
     if (!tables.next()) {
       LOG.fatal(
           String.format("Could not find the %s table. Did you run SqlInserts first?" +
-                            "Run 'java -jar yb-sample-apps.jar --help SqlUpdates' for more details",
+                            "Run 'java -jar yb-sample-apps.jar --help SqlUpdatesWithProcedures' for more details",
                         getTableName()));
       System.exit(1);
     }
@@ -97,6 +96,38 @@ public class SqlUpdates extends AppBase {
   public String getTableName() {
     String tableName = appConfig.tableName != null ? appConfig.tableName : DEFAULT_TABLE_NAME;
     return tableName.toLowerCase();
+  }
+
+  @Override
+  public void createStoredProcedures() throws Exception {
+    // Drop previous procedures.
+    getPostgresConnection().createStatement().execute(
+      String.format("DROP PROCEDURE IF EXISTS %s;", getStoredProcedureName()));
+
+    StringBuilder sb = new StringBuilder();
+    sb.append("CREATE PROCEDURE ").append(getStoredProcedureName()).append("(");
+    for (int i = 0; i < getBatchSize(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      sb.append("k").append(i).append(" text, v").append(i).append(" text");
+    }
+    sb.append(") AS '");
+    for (int i = 0; i < getBatchSize(); i++) {
+      sb.append("UPDATE ").append(getTableName())
+        .append(" SET v=v").append(i)
+        .append(" WHERE k=k").append(i).append(";");
+    }
+    sb.append("' LANGUAGE sql;");
+    getPostgresConnection().createStatement().execute(sb.toString());
+  }
+
+  public String getStoredProcedureName() {
+    return appConfig.storedProcedureName;
+  }
+
+  public int getBatchSize() {
+    return appConfig.updateBatchSize;
   }
 
   private PreparedStatement getPreparedSelect() throws Exception {
@@ -143,7 +174,6 @@ public class SqlUpdates extends AppBase {
       LOG.fatal("Failed reading value: " + key.getValueStr(), e);
       return 0;
     }
-
     // Mark this key as completed.
     getSimpleLoadGenerator().addCompletedKey(key);
     return 1;
@@ -151,29 +181,51 @@ public class SqlUpdates extends AppBase {
 
   private PreparedStatement getPreparedUpdate() throws Exception {
     if (preparedInsert == null) {
-      preparedInsert = getPostgresConnection().prepareStatement(
-          String.format("UPDATE %s SET v=? WHERE k=?;", getTableName()));
+      StringBuilder sb = new StringBuilder();
+      sb.append("CALL ").append(getStoredProcedureName()).append("(");
+      for (int i = 0; i < getBatchSize(); i++) {
+        if (i > 0) {
+          sb.append(",");
+        }
+        sb.append(" ? , ? ");
+      }
+      sb.append(");");
+      preparedInsert = getPostgresConnection().prepareCall(sb.toString());
     }
     return preparedInsert;
   }
 
   @Override
   public long doWrite(int threadIdx) {
-    // Get a key that has already been written (will need to implicitly read it to update).
-    Key key = getSimpleLoadGenerator().getKeyToRead();
-    if (key == null) {
-      return 0;
+    List<Key> keys = new ArrayList<>(getBatchSize());
+    for (int i = 0; i < getBatchSize(); i++) {
+      // Get a key that has already been written (will need to implicitly read it to update).
+      Key key = getSimpleLoadGenerator().getKeyToRead();
+      if (key == null) {
+        if (i == 0) {
+          // No more keys to read.
+          return 0;
+        }
+        // Still have a few keys left to update, so just duplicate the first key.
+        key = keys.get(0);
+      }
+      keys.add(key);
     }
 
     int result = 0;
     try {
       PreparedStatement statement = getPreparedUpdate();
       // Prefix hashcode to ensure generated keys are random and not sequential.
-      statement.setString(1, key.getValueStr() + ":" + System.currentTimeMillis());
-      statement.setString(2, key.asString());
-      result = statement.executeUpdate();
+      for (int i = 0; i < getBatchSize(); i++) {
+        Key key = keys.get(i);
+        statement.setString(2 * i + 1, key.asString());
+        statement.setString(2 * i + 2, key.getValueStr() + ":" + System.currentTimeMillis());
+      }
+      statement.executeUpdate();
+      // All updates went through.
+      result = getBatchSize();
     } catch (Exception e) {
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.fatal("Failed writing keys: " + Arrays.toString(keys.toArray()), e);
     }
     return result;
   }
@@ -182,16 +234,19 @@ public class SqlUpdates extends AppBase {
   public List<String> getWorkloadDescription() {
     return Arrays.asList(
         "Sample key-value app built on PostgreSQL with concurrent readers and writers. ",
+        "Similar to the SqlUpdates workload, except that this workload uses SQL procedures",
+        "to batch update statements together.",
         "The app updates existing string keys loaded by a run of the SqlInserts sample app.",
         "There are multiple readers and writers that update these keys and read them",
         "indefinitely, with the readers query the keys by the associated values that are",
         "indexed. Note that the number of reads and writes to perform can be specified as",
         "a parameter.",
-        "It requires two additional options: ",
+        "It requires three additional options: ",
         "   1. --max_written_key: set to the max key written by the SqlInserts app run.",
         "   2. --uuid: set to the uuid to the uuid prefix used by SqlInserts (recommended ",
         "     to (re)run SqlInserts with the '--uuid' option set, otherwise select from the ",
         "    " + getTableName() + " table to find out the used uuid.",
+        "   3. --update_batch_size: set to number of updates to perform per procedure call.",
         "Example, run SqlInserts before as follows:",
         "java -jar yb-sample-apps.jar --workload SqlInserts --nodes 127.0.0.1:5433 \\",
         "                             --uuid 'ffffffff-ffff-ffff-ffff-ffffffffffff' \\",
@@ -203,8 +258,10 @@ public class SqlUpdates extends AppBase {
   @Override
   public List<String> getWorkloadRequiredArguments() {
     return Arrays.asList(
-        "--uuid 'ffffffff-ffff-ffff-ffff-ffffffffffff'",
-        "--max_written_key 100000");
+      "--uuid 'ffffffff-ffff-ffff-ffff-ffffffffffff'",
+      "--update_batch_size " + appConfig.updateBatchSize,
+      "--stored_procedure_name " + appConfig.storedProcedureName,
+      "--max_written_key 100000");
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdatesWithProcedures.java
@@ -67,7 +67,7 @@ public class SqlUpdatesWithProcedures extends AppBase {
   }
 
   @Override
-  public void createTablesIfNeeded() throws Exception {
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
     // Check that (extra_ required options are set (maxWrittenKey and loadTesterUUID) set.
     if (appConfig.maxWrittenKey <= 0) {
       LOG.fatal("Workload requires option --max_written_key to be set. \n " +

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -369,6 +369,17 @@ public class CmdLineOpts {
                              AppBase.appConfig.numConsecutiveRowsWithSameFk));
     }
 
+    if (appName.equals(SqlUpdatesWithProcedures.class.getSimpleName())) {
+      if (commandLine.hasOption("update_batch_size")) {
+        AppBase.appConfig.updateBatchSize =
+                Integer.parseInt(commandLine.getOptionValue("update_batch_size"));
+      }
+
+      if (commandLine.hasOption("stored_procedure_name")) {
+        AppBase.appConfig.storedProcedureName = commandLine.getOptionValue("stored_procedure_name");
+      }
+    }
+
   }
 
   /**
@@ -765,6 +776,13 @@ public class CmdLineOpts {
 
     options.addOption("num_consecutive_rows_with_same_fk", true,
                       "[SqlDataLoad] Number of secondary indexes on the target table.");
+
+    // Options for SqlUpdatesWithProcedures.
+    options.addOption("update_batch_size", true,
+                      "[SqlUpdatesWithProcedures] Number of updates per procedure call.");
+
+    options.addOption("stored_procedure_name", true,
+                      "[SqlUpdatesWithProcedures] Name of stored procedure call to create and use.");
 
     // First check if a "--help" argument is passed with a simple parser. Note that if we add
     // required args, then the help string would not work. See:

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -208,7 +208,7 @@ public class SimpleLoadGenerator {
     return retKey;
   }
 
-  public Key getKey(KeyComparator kc, int maxAttempts) {
+  public Key getKey(KeyComparator kc, long maxAttempts) {
     long maxKey = maxWrittenKey.get();
     if (maxKey < 0) {
       return null;
@@ -231,7 +231,7 @@ public class SimpleLoadGenerator {
 
   public Key getKeyToUpdate() {
     // Find a unupdated key that has not failed or been updated yet.
-    Key key = getKey((k) -> (!failedKeys.contains(k) && !updatedKeys.contains(k)), 100);
+    Key key = getKey((k) -> (!failedKeys.contains(k) && !updatedKeys.contains(k)), maxWrittenKey.get());
     if (key != null && updatedKeys.add(key.asNumber())) {
       return key;
     }
@@ -241,7 +241,7 @@ public class SimpleLoadGenerator {
 
   public Key getUpdatedKeyToRead() {
     // Find a key that has not failed and that has been updated.
-    return getKey((key) -> (!failedKeys.contains(key) && updatedKeys.contains(key)), 100);
+    return getKey((key) -> (!failedKeys.contains(key) && updatedKeys.contains(key)), maxWrittenKey.get());
   }
 
   public long getMaxWrittenKey() {

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -98,7 +98,7 @@ public class SimpleLoadGenerator {
   final Set<Long> failedKeys;
   // Keys that have been written above maxWrittenKey.
   final Set<Long> writtenKeys;
-  // Keys that have been updated.
+  // Keys that have been updated, currently only used for SqlUpdatesWithProcedures.
   final Set<Long> updatedKeys;
   // A background thread to track keys written and increment maxWrittenKey.
   Thread writtenKeysTracker;

--- a/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
+++ b/src/main/java/com/yugabyte/sample/common/SimpleLoadGenerator.java
@@ -96,6 +96,8 @@ public class SimpleLoadGenerator {
   final Set<Long> failedKeys;
   // Keys that have been written above maxWrittenKey.
   final Set<Long> writtenKeys;
+  // Keys that have been written to and read, currently just used for Updates.
+  final Set<Long> completedKeys;
   // A background thread to track keys written and increment maxWrittenKey.
   Thread writtenKeysTracker;
   // The prefix for the key.
@@ -111,6 +113,7 @@ public class SimpleLoadGenerator {
     this.maxGeneratedKey = new AtomicLong(maxWrittenKey);
     failedKeys = new HashSet<Long>();
     writtenKeys = new HashSet<Long>();
+    completedKeys = new HashSet<Long>();
     writtenKeysTracker = new Thread("Written Keys Tracker") {
         @Override
         public void run() {
@@ -163,6 +166,12 @@ public class SimpleLoadGenerator {
     }
   }
 
+  public void addCompletedKey(Key key) {
+    if (key != null) {
+      completedKeys.add(key.asNumber());
+    }
+  }
+
   // Always returns a non-null key.
   public Key getKeyToWrite() {
     Key retKey = null;
@@ -194,7 +203,7 @@ public class SimpleLoadGenerator {
     }
     do {
       long key = ThreadLocalRandom.current().nextLong(maxKey);
-      if (!failedKeys.contains(key))
+      if (!failedKeys.contains(key) && !completedKeys.contains(key))
         return generateKey(key);
     } while (true);
   }


### PR DESCRIPTION
Same as #37 but with fixes for the build (previous pull request was missing the latest commit from master, and so there was a build error around `apps/SqlUpdatesWithProcedures.java:[69,3] method does not override or implement a method from a supertype`).

_Old PR message from #37:_
> Adding a new workload that is similar to SqlUpdates but that uses sql procedures in order to batch the updates together (see batching of updates in yugabyte/yugabyte-db#5257).

---

As mentioned in the comments of #37, `SqlUpdatesWithProcedures` differs from `SqlUpdates` in that this workload will only send `num_writes` **unique** updates (the uniqueness is to avoid transaction conflicts). Thus this workload can also be used for performance timing, as it will exit after it has finished all its updates.

Typical use case of this commit is via first running SqlInserts:
```
java -jar yb-sample-apps.jar --workload SqlInserts --nodes a:5433,b:5433,c:5433 --num_unique_keys 5000000 --num_reads 0 --num_threads_write 128 --uuid 'ffffffff-ffff-ffff-ffff-ffffffffffff'
```
Then by running SqlUpdatesWithProcedures:
```
java -jar yb-sample-apps.jar --workload SqlUpdatesWithProcedures --nodes a:5433,b:5433,c:5433 --uuid 'ffffffff-ffff-ffff-ffff-ffffffffffff' --max_written_key 5000000 --num_writes 1000000 --num_reads 0 --num_threads_read 0 --num_threads_write XXX --update_batch_size YYY
```
A few things to note:
- Notice that num_writes is lower than max_written_key, this is mostly to ensure that we don't have issues randomly selecting the last remaining keys to update at the end
- With the way the workload is currently written, the max `update_batch_size` is 50 since postgres only allows procedures to have at most 100 parameters, and we are currently just passing in key/value pairs to be updated (100/2 = 50).
