### PR TITLE
Reconnect sql when current connection has error

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -195,7 +195,8 @@ public class SqlDataLoad extends AppBase {
                 }
             }
         } catch (Exception e) {
-            LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+            LOG.info("Failed reading value: " + key.getValueStr(), e);
+            preparedSelect = null;
             return 0;
         }
         return 1;
@@ -259,7 +260,8 @@ public class SqlDataLoad extends AppBase {
             for (Key key : keys) {
                 getSimpleLoadGenerator().recordWriteFailure(key);
             }
-            LOG.fatal("Failed write with error: " + e.getMessage());
+            LOG.info("Failed write with error: " + e.getMessage());
+            preparedInsert = null;
         }
         return keys.size();
     }

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -197,7 +197,10 @@ public class SqlForeignKeysAndJoins extends AppBase {
         LOG.debug("Got " + count + " orders for user : " + key.toString());
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      synchronized (prepareInitLock) {
+        preparedSelect = null;
+      }
       return 0;
     }
     return 1;
@@ -263,7 +266,10 @@ public class SqlForeignKeysAndJoins extends AppBase {
       return 1;
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      synchronized (prepareInitLock) {
+        preparedInsertUser = null;
+      }
     }
     return 0;
   }
@@ -289,7 +295,10 @@ public class SqlForeignKeysAndJoins extends AppBase {
       return 1;
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      synchronized (prepareInitLock) {
+        preparedInsertOrder = null;
+      }
     }
     return 0;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -159,7 +159,8 @@ public class SqlGeoPartitionedTable extends AppBase {
         }
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      preparedSelect = null;
       return 0;
     }
     return 1;
@@ -194,7 +195,8 @@ public class SqlGeoPartitionedTable extends AppBase {
       getSimpleLoadGenerator().recordWriteSuccess(key);
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      preparedInsert = null;
     }
     return result;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -136,7 +136,8 @@ public class SqlInserts extends AppBase {
         }
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      preparedSelect = null;
       return 0;
     }
     return 1;
@@ -169,7 +170,8 @@ public class SqlInserts extends AppBase {
       getSimpleLoadGenerator().recordWriteSuccess(key);
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      preparedInsert = null;
     }
     return result;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
@@ -143,7 +143,8 @@ public class SqlSecondaryIndex extends AppBase {
         }
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      preparedSelect = null;
       return 0;
     }
     return 1;
@@ -176,7 +177,8 @@ public class SqlSecondaryIndex extends AppBase {
       getSimpleLoadGenerator().recordWriteSuccess(key);
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      preparedInsert = null;
     }
     return result;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -133,7 +133,8 @@ public class SqlSnapshotTxns extends AppBase {
         }
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      preparedSelect = null;
       return 0;
     }
     return 1;
@@ -172,7 +173,8 @@ public class SqlSnapshotTxns extends AppBase {
       return 1;
     } catch (Exception e) {
       getSimpleLoadGenerator().recordWriteFailure(key);
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      preparedInsert = null;
     }
     return 0;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -137,7 +137,8 @@ public class SqlUpdates extends AppBase {
         }
       }
     } catch (Exception e) {
-      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      LOG.info("Failed reading value: " + key.getValueStr(), e);
+      preparedSelect = null;
       return 0;
     }
     return 1;
@@ -167,7 +168,8 @@ public class SqlUpdates extends AppBase {
       statement.setString(2, key.asString());
       result = statement.executeUpdate();
     } catch (Exception e) {
-      LOG.fatal("Failed writing key: " + key.asString(), e);
+      LOG.info("Failed writing key: " + key.asString(), e);
+      preparedInsert = null;
     }
     return result;
   }


### PR DESCRIPTION
Operations in Sql classes such as SqlInserts would keep retrying upon connection errors.

Start SqlInserts workload of the sample app against a running local cluster, then stop some TS process (which the sample app connects to) in the local cluster (the cluster as a whole is still available), and the sample app resumes normal operations by getting connection to running TS.