### PR TITLE
Add local_reads option for SQL apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.2</version>
+      <version>42.2.18</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -160,7 +160,11 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
       props.setProperty("password", password);
     }
     props.setProperty("sslmode", "disable");
-    props.put("reWriteBatchedInserts", "true");
+    props.setProperty("reWriteBatchedInserts", "true");
+    if (appConfig.localReads) {
+      props.setProperty("options", "-c yb_read_from_followers=true");
+    }
+
     String connectStr = String.format("jdbc:postgresql://%s:%d/%s", contactPoint.getHost(),
                                                                     contactPoint.getPort(),
                                                                     database);


### PR DESCRIPTION
Use the `--local_reads` option to enable read from followers for any SQL sample app.
This will set the `yb_read_from_followers` session variable to true for every SQL connection.

For instance, for `SqlInserts` use:
```
java -jar target/yb-sample-apps.jar --workload SqlInserts --nodes 127.0.0.3:5433 --local_reads
```

Note: If testing locally using `yb-ctl` make sure to set the placement info so that routing can identify the local/remote nodes.
For instance, run `yb-ctl` as follows:
```
/bin/yb-ctl create --rf 3 --placement_info "cloud1.region1.zone1,cloud2.region2.zone2,cloud3.region3.zone3"
```