### PR TITLE
Add SqlGeoPartitionedTable app

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -185,4 +185,6 @@ public class AppConfig {
   public int numForeignKeyTableRows = 1000; // Only relevant if num_foreign_keys > 0.
   public int numConsecutiveRowsWithSameFk = 500; // Only relevant if num_foreign_keys > 0.
 
+  // Configurations for SqlGeoPartitionedTable workload.
+  public int numPartitions = 2;
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -79,7 +79,7 @@ public class SqlGeoPartitionedTable extends AppBase {
     try (Connection connection = getPostgresConnection();
          Statement statement = connection.createStatement()) {
 
-      // (Re)Create the table (every run should start cleanly with an empty table).
+      // Drop the table if requested.
       if (tableOp.equals(TableOp.DropTable)) {
         statement.execute(String.format("DROP TABLE IF EXISTS %s", getTableName()));
         LOG.info("Dropping any table(s) left from previous runs if any");

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -1,0 +1,222 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+package com.yugabyte.sample.apps;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
+
+/**
+ * This workload writes and reads some random string keys from a postgresql table.
+ */
+public class SqlGeoPartitionedTable extends AppBase {
+  private static final Logger LOG = Logger.getLogger(SqlGeoPartitionedTable.class);
+
+  // Static initialization of this workload's config. These are good defaults for getting a decent
+  // read dominated workload on a reasonably powered machine. Exact IOPS will of course vary
+  // depending on the machine and what resources it has to spare.
+  static {
+    // Disable the read-write percentage.
+    appConfig.readIOPSPercentage = -1;
+    // Set the read and write threads to 2 each.
+    appConfig.numReaderThreads = 2;
+    appConfig.numWriterThreads = 2;
+    // The number of keys to read.
+    appConfig.numKeysToRead = -1;
+    // The number of keys to write. This is the combined total number of inserts and updates.
+    appConfig.numKeysToWrite = -1;
+    // The number of unique keys to write. This determines the number of inserts (as opposed to
+    // updates).
+    appConfig.numUniqueKeysToWrite = NUM_UNIQUE_KEYS;
+  }
+
+  // The default table name to create and use for CRUD ops.
+  private static final String DEFAULT_TABLE_NAME = "SqlGeoPartitionedTable";
+
+  // The shared prepared select statement for fetching the data.
+  private volatile PreparedStatement preparedSelect = null;
+
+  // The shared prepared insert statement for inserting the data.
+  private volatile PreparedStatement preparedInsert = null;
+
+  // Lock for initializing prepared statement objects.
+  private static final Object prepareInitLock = new Object();
+
+  public SqlGeoPartitionedTable() {
+    buffer = new byte[appConfig.valueSize];
+  }
+
+  /**
+   * Drop the table created by this app.
+   */
+  @Override
+  public void dropTable() throws Exception {
+    Connection connection = getPostgresConnection();
+    connection.createStatement().execute("DROP TABLE " + getTableName());
+    LOG.info(String.format("Dropped table: %s", getTableName()));
+  }
+
+  @Override
+  public void createTablesIfNeeded(TableOp tableOp) throws Exception {
+
+    try (Connection connection = getPostgresConnection();
+         Statement statement = connection.createStatement()) {
+
+      // (Re)Create the table (every run should start cleanly with an empty table).
+      if (tableOp.equals(TableOp.DropTable)) {
+        statement.execute(String.format("DROP TABLE IF EXISTS %s", getTableName()));
+        LOG.info("Dropping any table(s) left from previous runs if any");
+      }
+
+      // TODO Creating the primary keys on each partition because of issue #6149.
+      statement.execute(
+          String.format("CREATE TABLE IF NOT EXISTS %s (region text, k text, v text) " +
+                            "PARTITION BY LIST (region)", getTableName()));
+      // Creating partitions.
+      for (int i = 0; i < appConfig.numPartitions; i++) {
+        statement.execute(
+            String.format("CREATE TABLE IF NOT EXISTS %1$s_%2$d PARTITION OF %1$s (" +
+                              "region, k, v, PRIMARY KEY((region, k) HASH))" +
+                              " FOR VALUES IN ('region_%2$d')",
+                          getTableName(), i));
+      }
+
+      LOG.info(String.format("Created (if not exists) table: %s", getTableName()));
+
+      if (tableOp.equals(TableOp.TruncateTable)) {
+        for (int i = 0; i < appConfig.numPartitions; i++) {
+          statement.execute(
+              String.format("TRUNCATE TABLE %s_%d", getTableName(), i));
+        }
+        LOG.info(String.format("Truncated table: %s", getTableName()));
+      }
+    }
+  }
+
+  public String getTableName() {
+    String tableName = appConfig.tableName != null ? appConfig.tableName : DEFAULT_TABLE_NAME;
+    return tableName.toLowerCase();
+  }
+
+  public String getRegion(Long key_number) {
+    return String.format("region_%d", key_number % appConfig.numPartitions);
+  }
+
+  private PreparedStatement getPreparedSelect() throws Exception {
+    if (preparedSelect == null) {
+      preparedSelect = getPostgresConnection().prepareStatement(
+          String.format("SELECT k, v FROM %s WHERE region = ? AND k = ?",
+                        getTableName()));
+    }
+    return preparedSelect;
+  }
+
+  @Override
+  public long doRead() {
+    Key key = getSimpleLoadGenerator().getKeyToRead();
+    if (key == null) {
+      // There are no keys to read yet.
+      return 0;
+    }
+
+    try {
+      PreparedStatement statement = getPreparedSelect();
+      statement.setString(1, getRegion(key.asNumber()));
+      statement.setString(2, key.asString());
+      try (ResultSet rs = statement.executeQuery()) {
+        if (!rs.next()) {
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got 0");
+          return 0;
+        }
+
+        if (!key.asString().equals(rs.getString("k"))) {
+          LOG.error("Read key: " + key.asString() + ", got " + rs.getString("k"));
+        }
+        LOG.debug("Read key: " + key.toString());
+
+        key.verify(rs.getString("v"));
+
+        if (rs.next()) {
+          LOG.error("Read key: " + key.asString() + " expected 1 row in result, got more");
+          return 0;
+        }
+      }
+    } catch (Exception e) {
+      LOG.fatal("Failed reading value: " + key.getValueStr(), e);
+      return 0;
+    }
+    return 1;
+  }
+
+  private PreparedStatement getPreparedInsert() throws Exception {
+    if (preparedInsert == null) {
+      preparedInsert = getPostgresConnection().prepareStatement(
+          String.format("INSERT INTO %s (region, k, v) VALUES (?, ?, ?)",
+                        getTableName()));
+    }
+    return preparedInsert;
+  }
+
+  @Override
+  public long doWrite(int threadIdx) {
+    Key key = getSimpleLoadGenerator().getKeyToWrite();
+    if (key == null) {
+      return 0;
+    }
+
+    int result = 0;
+    try {
+      PreparedStatement statement = getPreparedInsert();
+      // Prefix hashcode to ensure generated keys are random and not sequential.
+      statement.setString(1, getRegion(key.asNumber()));
+      statement.setString(2, key.asString());
+      statement.setString(3, key.getValueStr());
+      result = statement.executeUpdate();
+      LOG.debug("Wrote key: " + key.asString() + ", " + key.getValueStr() + ", return code: " +
+                    result);
+      getSimpleLoadGenerator().recordWriteSuccess(key);
+    } catch (Exception e) {
+      getSimpleLoadGenerator().recordWriteFailure(key);
+      LOG.fatal("Failed writing key: " + key.asString(), e);
+    }
+    return result;
+  }
+
+  @Override
+  public List<String> getWorkloadDescription() {
+    return Arrays.asList(
+        "Sample app based on SqlInserts but uses a geo-partitioned table.",
+        "It creates a list-partitioned table with an additional primary-key column ",
+        "'region', and a configurable number of partitions.",
+        "The value(s) for the new column (region) is automatically generated for each",
+        "read/write operation based on the randomly-generated key column ('k').");
+  }
+
+  @Override
+  public List<String> getWorkloadOptionalArguments() {
+    return Arrays.asList(
+        "--num_partitions " + appConfig.numPartitions,
+        "--num_threads_read " + appConfig.numReaderThreads,
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
+        "--num_reads " + appConfig.numKeysToRead,
+        "--num_writes " + appConfig.numKeysToWrite);
+  }
+}

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -369,6 +369,17 @@ public class CmdLineOpts {
                              AppBase.appConfig.numConsecutiveRowsWithSameFk));
     }
 
+    if (appName.equals(SqlGeoPartitionedTable.class.getSimpleName())) {
+
+      if (commandLine.hasOption("num_partitions")) {
+        AppBase.appConfig.numPartitions =
+                Integer.parseInt(commandLine.getOptionValue("num_partitions"));
+      }
+      LOG.info(String.format("SqlGeoPartitionedTable: will use %d partitions",
+                             AppBase.appConfig.numPartitions));
+    }
+
+
   }
 
   /**
@@ -765,6 +776,9 @@ public class CmdLineOpts {
 
     options.addOption("num_consecutive_rows_with_same_fk", true,
                       "[SqlDataLoad] Number of secondary indexes on the target table.");
+
+    options.addOption("num_partitions", true,
+                      "[SqlGeoPartitionedTable] Number of partitions to create.");
 
     // First check if a "--help" argument is passed with a simple parser. Note that if we add
     // required args, then the help string would not work. See:

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -370,7 +370,6 @@ public class CmdLineOpts {
     }
 
     if (appName.equals(SqlGeoPartitionedTable.class.getSimpleName())) {
-
       if (commandLine.hasOption("num_partitions")) {
         AppBase.appConfig.numPartitions =
                 Integer.parseInt(commandLine.getOptionValue("num_partitions"));


### PR DESCRIPTION
Adds a new sample app based on SqlInserts but using a geo-partitioned table.
It creates a list-partitioned table with an additional primary-key column
'region', and a configurable number of partitions.
The value(s) for the new column (region) is automatically generated for each,
read/write operation based on the randomly-generated key column ('k').


Can be used with, for instance:
```
java -jar target/yb-sample-apps.jar --workload SqlGeoPartitionedTable --nodes 127.0.0.1:5433 --num_partitions 5
```
Which will generate the following table schema:
```
                         Table "public.sqlgeopartitionedtable"
 Column | Type | Collation | Nullable | Default | Storage  | Stats target | Description
--------+------+-----------+----------+---------+----------+--------------+-------------
 region | text |           |          |         | extended |              |
 k      | text |           |          |         | extended |              |
 v      | text |           |          |         | extended |              |
Partition key: LIST (region)
Partitions: sqlgeopartitionedtable_0 FOR VALUES IN ('region_0'),
            sqlgeopartitionedtable_1 FOR VALUES IN ('region_1'),
            sqlgeopartitionedtable_2 FOR VALUES IN ('region_2'),
            sqlgeopartitionedtable_3 FOR VALUES IN ('region_3'),
            sqlgeopartitionedtable_4 FOR VALUES IN ('region_4')
```
And run the typical read/write workload configurable as usual with `num_threads_read`, `num_threads_write`, etc.




