### PR TITLE
Add flag to output parseable json metrics

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -39,6 +39,7 @@ import java.util.zip.Checksum;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
+import com.yugabyte.sample.common.metrics.Observation;
 import org.apache.log4j.Logger;
 
 import com.datastax.driver.core.Cluster;
@@ -666,7 +667,7 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
 
   private synchronized void initMetricsTracker() {
     if (metricsTracker == null) {
-      metricsTracker = new MetricsTracker();
+      metricsTracker = new MetricsTracker(appConfig.outputJsonMetrics);
       if (appConfig.appType == AppConfig.Type.OLTP) {
         metricsTracker.createMetric(MetricName.Read);
         metricsTracker.createMetric(MetricName.Write);
@@ -743,7 +744,8 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
     if (count > 0) {
       numKeysWritten.addAndGet(count);
       if (metricsTracker != null) {
-        metricsTracker.getMetric(MetricName.Write).accumulate(count, endTs - startTs);
+        Observation o = new Observation(count, startTs, endTs);
+        metricsTracker.getMetric(MetricName.Write).observe(o);
       }
     }
   }
@@ -768,7 +770,8 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
     if (count > 0) {
       numKeysRead.addAndGet(count);
       if (metricsTracker != null) {
-        metricsTracker.getMetric(MetricName.Read).accumulate(count, endTs - startTs);
+        Observation o = new Observation(count, startTs, endTs);
+        metricsTracker.getMetric(MetricName.Read).observe(o);
       }
     }
   }

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -188,6 +188,6 @@ public class AppConfig {
   // Configurations for SqlGeoPartitionedTable workload.
   public int numPartitions = 2;
 
-  // Determines whether we should output JSON metrics instead of human-readable metrics.
+  // Determines whether we should output JSON metrics in addition to human-readable metrics.
   public boolean outputJsonMetrics = false;
 }

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -187,4 +187,7 @@ public class AppConfig {
 
   // Configurations for SqlGeoPartitionedTable workload.
   public int numPartitions = 2;
+
+  // Determines whether we should output JSON metrics instead of human-readable metrics.
+  public boolean outputJsonMetrics = false;
 }

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -153,6 +153,9 @@ public class CmdLineOpts {
     }
     LOG.info("Local reads: " + localReads);
     LOG.info("Read only load: " + readOnly);
+    if (commandLine.hasOption("output_json_metrics")) {
+      AppBase.appConfig.outputJsonMetrics = true;
+    }
     if (appName.equals(CassandraBatchTimeseries.class.getSimpleName())) {
       if (commandLine.hasOption("read_batch_size")) {
         AppBase.appConfig.cassandraReadBatchSize =
@@ -665,6 +668,9 @@ public class CmdLineOpts {
       "Use an SSL connection while connecting to YugaByte.");
     options.addOption("batch_size", true,
                       "Number of keys to write in a batch (for apps that support batching).");
+    options.addOption(
+        "output_json_metrics", false,
+        "If true, output JSON metrics in addition to human-readable metrics to stdout.");
 
     // Options for CassandraTimeseries workload.
     options.addOption("num_users", true, "[CassandraTimeseries] The total number of users.");

--- a/src/main/java/com/yugabyte/sample/common/metrics/JsonStatsMetric.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/JsonStatsMetric.java
@@ -15,25 +15,26 @@ package com.yugabyte.sample.common.metrics;
 
 import com.google.gson.JsonObject;
 
-public class Metric {
-  private ReadableStatsMetric readableStatsMetric;
-  private JsonStatsMetric jsonStatsMetric;
+public class JsonStatsMetric {
+    private StatsTracker latency;
+    private ThroughputStats throughput;
+    private final String name;
 
-  public Metric(String name) {
-    readableStatsMetric = new ReadableStatsMetric(name);
-    jsonStatsMetric = new JsonStatsMetric(name);
-  }
+    public JsonStatsMetric(String name) {
+        latency = new StatsTracker();
+        throughput = new ThroughputStats();
+        this.name = name;
+    }
 
-  public synchronized void observe(Observation o) {
-    readableStatsMetric.accumulate(o.getCount(), o.getLatencyNanos());
-    jsonStatsMetric.observe(o);
-  }
+    public synchronized void observe(Observation o) {
+        throughput.observe(o);
+        latency.observe(o.getLatencyNanos());
+    }
 
-  public String getReadableMetricsAndReset() {
-    return readableStatsMetric.getMetricsAndReset();
-  }
-
-  public JsonObject getJsonMetrics() {
-    return jsonStatsMetric.getJson();
-  }
+    public synchronized JsonObject getJson() {
+        JsonObject json = new JsonObject();
+        json.add("latency", latency.getJson());
+        json.add("throughput", throughput.getJson());
+        return json;
+    }
 }

--- a/src/main/java/com/yugabyte/sample/common/metrics/MetricsTracker.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/MetricsTracker.java
@@ -16,48 +16,43 @@ package com.yugabyte.sample.common.metrics;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.gson.JsonObject;
 import org.apache.log4j.Logger;
 
 public class MetricsTracker extends Thread {
   private static final Logger LOG = Logger.getLogger(MetricsTracker.class);
+  private final boolean outputJsonMetrics;
 
   // Interface to print custom messages.
-  public static interface StatusMessageAppender {
-    public String appenderName();
-    public void appendMessage(StringBuilder sb);
+  public interface StatusMessageAppender {
+    String appenderName();
+    void appendMessage(StringBuilder sb);
   }
 
   // The type of metrics supported.
-  public static enum MetricName {
+  public enum MetricName {
     Read,
     Write,
   }
   // Map to store all the metrics objects.
   Map<MetricName, Metric> metrics = new ConcurrentHashMap<MetricName, Metric>();
-  // Track reads.
-  Metric reads = new Metric("Reads");
-  // Track writes.
-  Metric writes = new Metric("Writes");
   // State variable to make sure this thread is started exactly once.
   boolean hasStarted = false;
-  Object initLock = new Object();
   // Map of custom appenders.
-  Map<String, StatusMessageAppender> appenders =
-      new ConcurrentHashMap<String, StatusMessageAppender>();
+  Map<String, StatusMessageAppender> appenders = new ConcurrentHashMap<String, StatusMessageAppender>();
 
-  public MetricsTracker() {
+  public MetricsTracker(boolean outputJsonMetrics) {
     this.setDaemon(true);
+    this.outputJsonMetrics = outputJsonMetrics;
   }
 
   public void registerStatusMessageAppender(StatusMessageAppender appender) {
     appenders.put(appender.appenderName(), appender);
   }
 
-  public void createMetric(MetricName metricName) {
-    synchronized (initLock) {
-      if (!metrics.containsKey(metricName)) {
-        metrics.put(metricName, new Metric(metricName.name()));
-      }
+  public synchronized void createMetric(MetricName metricName) {
+    if (!metrics.containsKey(metricName)) {
+      metrics.put(metricName, new Metric(metricName.name()));
     }
   }
 
@@ -65,19 +60,17 @@ public class MetricsTracker extends Thread {
     return metrics.get(metricName);
   }
 
-  public void getMetricsAndReset(StringBuilder sb) {
+  public void getReadableMetricsAndReset(StringBuilder sb) {
     for (MetricName metricName : MetricName.values()) {
-      sb.append(String.format("%s  |  ", metrics.get(metricName).getMetricsAndReset()));
+      sb.append(String.format("%s  |  ", metrics.get(metricName).getReadableMetricsAndReset()));
     }
   }
 
   @Override
-  public void start() {
-    synchronized (initLock) {
-      if (!hasStarted) {
-        hasStarted = true;
-        super.start();
-      }
+  public synchronized void start() {
+    if (!hasStarted) {
+      hasStarted = true;
+      super.start();
     }
   }
 
@@ -87,11 +80,19 @@ public class MetricsTracker extends Thread {
       try {
         Thread.sleep(5000);
         StringBuilder sb = new StringBuilder();
-        getMetricsAndReset(sb);
+        getReadableMetricsAndReset(sb);
         for (StatusMessageAppender appender : appenders.values()) {
           appender.appendMessage(sb);
         }
         LOG.info(sb.toString());
+
+        if (this.outputJsonMetrics) {
+          JsonObject json = new JsonObject();
+          for (MetricName metricName : MetricName.values()) {
+            json.add(metricName.name(), metrics.get(metricName).getJsonMetrics());
+          }
+          LOG.info(String.format("<json>%s</json>", json.toString()));
+        }
       } catch (InterruptedException e) {}
     }
   }

--- a/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
@@ -1,0 +1,34 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package com.yugabyte.sample.common.metrics;
+
+public class Observation {
+    private long count;
+    private long startTsNanos;
+    private long endTsNanos;
+
+    public Observation(long count, long startTsNanos, long endTsNanos) {
+        this.count = count;
+        this.startTsNanos = startTsNanos;
+        this.endTsNanos = endTsNanos;
+    }
+
+    public long getLatencyNanos() { return endTsNanos - startTsNanos; }
+
+    public long getCount() { return count; }
+
+    public long getStartTsNanos() { return startTsNanos; }
+
+    public long getEndTsNanos() { return endTsNanos; }
+}

--- a/src/main/java/com/yugabyte/sample/common/metrics/ReadableStatsMetric.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/ReadableStatsMetric.java
@@ -1,0 +1,56 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package com.yugabyte.sample.common.metrics;
+
+import org.apache.log4j.Logger;
+
+public class ReadableStatsMetric {
+    private static final Logger LOG = Logger.getLogger(ReadableStatsMetric.class);
+    String name;
+    private final Object lock = new Object();
+    protected long curOpCount = 0;
+    protected long curOpLatencyNanos = 0;
+    protected long totalOpCount = 0;
+    private long lastSnapshotNanos;
+
+    public ReadableStatsMetric(String name) {
+        this.name = name;
+        lastSnapshotNanos = System.nanoTime();
+    }
+
+    /**
+     * Accumulate metrics with operations processed as one batch.
+     * @param numOps number of ops processed as one batch
+     * @param batchLatencyNanos whole batch latency
+     */
+    public synchronized void accumulate(long numOps, long batchLatencyNanos) {
+        curOpCount += numOps;
+        curOpLatencyNanos += batchLatencyNanos * numOps;
+        totalOpCount += numOps;
+    }
+
+    public synchronized String getMetricsAndReset() {
+        long currNanos = System.nanoTime();
+        long elapsedNanos = currNanos - lastSnapshotNanos;
+        LOG.debug("currentOpLatency: " + curOpLatencyNanos + ", currentOpCount: " + curOpCount);
+        double ops_per_sec =
+                (elapsedNanos == 0) ? 0 : (curOpCount * 1000000000 * 1.0 / elapsedNanos);
+        double latency = (curOpCount == 0) ? 0 : (curOpLatencyNanos / 1000000 * 1.0 / curOpCount);
+        curOpCount = 0;
+        curOpLatencyNanos = 0;
+        lastSnapshotNanos = currNanos;
+        return String.format("%s: %.2f ops/sec (%.2f ms/op), %d total ops",
+                name, ops_per_sec, latency, totalOpCount);
+    }
+}

--- a/src/main/java/com/yugabyte/sample/common/metrics/StatsTracker.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/StatsTracker.java
@@ -1,0 +1,27 @@
+package com.yugabyte.sample.common.metrics;
+
+import com.google.gson.JsonObject;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+public class StatsTracker {
+    private DescriptiveStatistics stats;
+
+    public StatsTracker() {
+        this.stats = new DescriptiveStatistics();
+    }
+
+    public synchronized void observe(double value) {
+        stats.addValue(value);
+    }
+
+    public synchronized JsonObject getJson() {
+        JsonObject json = new JsonObject();
+        json.addProperty("mean", stats.getMean());
+        json.addProperty("variance", stats.getVariance());
+        json.addProperty("sampleSize", stats.getN());
+        json.addProperty("min", stats.getMin());
+        json.addProperty("max", stats.getMax());
+        json.addProperty("p99", stats.getPercentile(.99));
+        return json;
+    }
+}

--- a/src/main/java/com/yugabyte/sample/common/metrics/ThroughputObserver.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/ThroughputObserver.java
@@ -1,0 +1,46 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package com.yugabyte.sample.common.metrics;
+
+public class ThroughputObserver {
+    private final long startTsNanos; // inclusive
+    private final long endTsNanos; // exclusive
+    private long ops;
+
+    ThroughputObserver(long startTsNanos, long endTsNanos) {
+        this.startTsNanos = startTsNanos;
+        this.endTsNanos = endTsNanos;
+        this.ops = 0;
+    }
+
+    long observe(Observation o) {
+        long toAdd;
+        if (o.getEndTsNanos() < startTsNanos || endTsNanos <= o.getStartTsNanos()) {
+            toAdd = 0;
+        } else {
+            toAdd = o.getCount();
+        }
+        synchronized(this) {
+            ops += toAdd;
+        }
+
+        return toAdd;
+    }
+
+    synchronized long getOps() { return ops; }
+
+    long getStartTsNanos() { return startTsNanos; }
+
+    long getEndTsNanos() { return endTsNanos; }
+}

--- a/src/main/java/com/yugabyte/sample/common/metrics/ThroughputStats.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/ThroughputStats.java
@@ -1,0 +1,53 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+package com.yugabyte.sample.common.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.gson.JsonObject;
+
+public class ThroughputStats {
+    private ThroughputObserver activeObserver;
+
+    private StatsTracker throughput;
+
+    private static final long NANOS_PER_THROUGHPUT_OBSERVATION = TimeUnit.SECONDS.toNanos(1);
+
+    private ThroughputObserver getObserver(long startTsNanos) {
+        return new ThroughputObserver(startTsNanos, startTsNanos + NANOS_PER_THROUGHPUT_OBSERVATION);
+    }
+
+    public ThroughputStats() {
+        this.activeObserver = null;
+        this.throughput = new StatsTracker();
+    }
+
+    public void observe(Observation o) {
+        if (activeObserver == null) {
+            activeObserver = getObserver(o.getStartTsNanos());
+        }
+        long observedSoFar = activeObserver.observe(o);
+        while (observedSoFar < o.getCount() && activeObserver.getStartTsNanos() < o.getEndTsNanos()) {
+            throughput.observe(activeObserver.getOps());
+            long oldEndTsNanos = activeObserver.getEndTsNanos();
+            activeObserver = getObserver(oldEndTsNanos);
+            observedSoFar += activeObserver.observe(o);
+        }
+        assert (observedSoFar == o.getCount());
+    }
+
+    public synchronized JsonObject getJson() {
+        return throughput.getJson();
+    }
+}


### PR DESCRIPTION
Add --output_json_metrics flag to trigger parseable json metrics to be logged when running sample apps.

Example:
```
$ java -jar yb-sample-apps.jar --workload SqlSecondaryIndex --nodes $IPS --num_threads_read 2 --num_threads_write 2 --num_unique_keys 1000000
...
14875 [Thread-1] INFO com.yugabyte.sample.common.metrics.MetricsTracker  - Read: 939.51 ops/sec (1.95 ms/op), 4712 total ops  |  Write: 236.51 ops/sec (8.38 ms/op), 1183 total ops  |  Uptime: 5019 ms |
14901 [Thread-1] INFO com.yugabyte.sample.common.metrics.MetricsTracker  - <json>{"Read":{"latency":{"mean":1954115.1034994684,"variance":4.01113298862315E13,"sampleSize":471
5,"min":938633.0,"max":2.73514324E8,"p99":1057826.166},"throughput":{"mean":1020.25,"variance":9037.583333333334,"sampleSize":4,"min":918.0,"max":1148.0,"p99":918.0}},"Write":{"latency":{"mean":8365669.521079248,"variance":3.5343125181880106E
14,"sampleSize":1186,"min":2259319.0,"max":3.95759913E8,"p99":2414782.5218},"throughput":{"mean":236.8,"variance":10655.2,"sampleSize":5,"min":71.0,"max":345.0,"p99":71.0}}}</json>
...
```

Note that usage of this flag does not stop the human-readable text output from being logged as well.

It's worth noting the following differences in the semantics of these json metrics, as compared to the human-readable metrics:
- The json metrics are representative of cumulative data, whereas the data used in human readable metrics are reset every time they're logged
- Throughput is measured by sampling one data point every second based on the number of requests which finished in the last second
- We now output the sample size with the json metrics. This is important to enable downstream statistical hypothesis testing comparing multiple runs