### PR TITLE
Output latency metrics in millis

### DIFF
--- a/src/main/java/com/yugabyte/sample/common/metrics/JsonStatsMetric.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/JsonStatsMetric.java
@@ -28,7 +28,7 @@ public class JsonStatsMetric {
 
     public synchronized void observe(Observation o) {
         throughput.observe(o);
-        latency.observe(o.getLatencyNanos());
+        latency.observe(o.getLatencyMillis());
     }
 
     public synchronized JsonObject getJson() {

--- a/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
@@ -28,7 +28,9 @@ public class Observation {
 
     public long getLatencyNanos() { return endTsNanos - startTsNanos; }
 
-    public long getLatencyMillis() { return TimeUnit.NANOSECONDS.toMillis(getLatencyNanos()); }
+    public double getLatencyMillis() {
+        return ((double) getLatencyNanos()) / ((double) TimeUnit.MILLISECONDS.toNanos(1));
+    }
 
     public long getCount() { return count; }
 

--- a/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/Observation.java
@@ -13,6 +13,8 @@
 
 package com.yugabyte.sample.common.metrics;
 
+import java.util.concurrent.TimeUnit;
+
 public class Observation {
     private long count;
     private long startTsNanos;
@@ -25,6 +27,8 @@ public class Observation {
     }
 
     public long getLatencyNanos() { return endTsNanos - startTsNanos; }
+
+    public long getLatencyMillis() { return TimeUnit.NANOSECONDS.toMillis(getLatencyNanos()); }
 
     public long getCount() { return count; }
 


### PR DESCRIPTION
Previously, when running the following command:

java -jar target/yb-sample-apps.jar --workload CassandraKeyValue  --nodes 127.0.0.1:9042 --output_json_metrics

we would see output like:

6792 [Thread-2] INFO com.yugabyte.sample.common.metrics.MetricsTracker  - <json>{"Read":{"latency":{"mean":1484043.161940312,"variance":2.5166510662849356E11,"sampleSize":69186,"min":431077.0,"max":1.1387635E7,"p99":693622.5617},"throughput":{"mean":13280.0,"variance":1.1659124666666666E7,"sampleSize":4,"min":8262.0,"max":15920.0,"p99":8262.0}},"Write":{"latency":{"mean":1870880.7887033205,"variance":5.208910299786783E11,"sampleSize":5329,"min":516879.0,"max":1.131751E7,"p99":807463.768},"throughput":{"mean":1055.4,"variance":49592.8,"sampleSize":5,"min":895.0,"max":1430.0,"p99":895.0}}}</json>

Note that measurements for latency are in terms of nanoseconds. Because we ultimately want to present and compare data in terms of milliseconds, this output format was unnecessarily complicated to deal with in ptest. This PR changes the behavior to output latency in terms of milliseconds.