### PR TITLE
Fix p99 statistic calculation

### DIFF
--- a/src/main/java/com/yugabyte/sample/common/metrics/StatsTracker.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/StatsTracker.java
@@ -21,7 +21,7 @@ public class StatsTracker {
         json.addProperty("sampleSize", stats.getN());
         json.addProperty("min", stats.getMin());
         json.addProperty("max", stats.getMax());
-        json.addProperty("p99", stats.getPercentile(.99));
+        json.addProperty("p99", stats.getPercentile(99));
         return json;
     }
 }


### PR DESCRIPTION
Based on docs for DescriptiveStats, we need to pass in the percentile in (0,100]. Previously we were erroneously calling with .99, when we should be calling with 99.

See: https://commons.apache.org/proper/commons-math/javadocs/api-3.3/org/apache/commons/math3/stat/descriptive/DescriptiveStatistics.html#getPercentile(double)