### PR TITLE
Allowing TLS connections from yb-sample-apps to postgres.

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -178,6 +178,13 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
           props.setProperty("options", "-c yb_read_from_followers=true");
         }
 
+        if (appConfig.sslCert != null && appConfig.sslCert.length() > 0) {
+          assert(appConfig.sslKey != null && appConfig.sslKey.length() > 0) : "The SSL key is empty.";
+          props.put("sslmode", "require");
+          props.put("sslcert", appConfig.sslCert);
+          props.put("sslkey", appConfig.sslKey);
+        }
+
         String connectStr = String.format("jdbc:postgresql://%s:%d/%s", contactPoint.getHost(),
                                                                         contactPoint.getPort(),
                                                                         database);

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -171,8 +171,10 @@ public class AppConfig {
   // The number of client connections to establish to each host in the YugaByte DB cluster.
   public int concurrentClients = 4;
 
-  // The path to the certificate to be used for the SSL connection.
+  // The path to the certificate and the key to be used for the SSL connection.
   public String sslCert = null;
+  public String sslKey = null;
+
   // Number of devices to simulate data for CassandraEventData workload
   public int num_devices = 100;
   // Number of Event Types per device to simulate data for CassandraEventData workload

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -331,6 +331,9 @@ public class CmdLineOpts {
     if (commandLine.hasOption("ssl_cert")) {
       AppBase.appConfig.sslCert = commandLine.getOptionValue("ssl_cert");
     }
+    if (commandLine.hasOption("ssl_key")) {
+      AppBase.appConfig.sslKey = commandLine.getOptionValue("ssl_key");
+    }
 
     if (commandLine.hasOption("num_indexes")) {
       AppBase.appConfig.numIndexes =
@@ -665,6 +668,8 @@ public class CmdLineOpts {
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true,
+      "Use an SSL connection while connecting to YugaByte.");
+    options.addOption("ssl_key", true,
       "Use an SSL connection while connecting to YugaByte.");
     options.addOption("batch_size", true,
                       "Number of keys to write in a batch (for apps that support batching).");


### PR DESCRIPTION
Summary:
Enabling TLS connections need the server key and server cert files to be
passed as arguments:

java -jar target/yb-sample-apps.jar \
--workload SqlInserts \
--nodes ip1 \
--ssl_key /home/centos/yugabytedb.key.der \
--ssl_cert /home/centos/yugabytedb.crt

The key needs to be in the binary DER format instead of the pem
format which can be done as follows:

openssl pkcs8 -topk8 -inform PEM -in yugabytedb.key -outform DER -out yugabytedb.key.der  -v1 PBE-MD5-DES -nocrypt

Reviewers:
Mihnea