### PR TITLE
Sample apps fails to connect to TLS enabled clusters that don't need client certs

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -172,7 +172,6 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         if (password != null) {
           props.setProperty("password", password);
         }
-        props.setProperty("sslmode", "disable");
         props.setProperty("reWriteBatchedInserts", "true");
         if (appConfig.localReads) {
           props.setProperty("options", "-c yb_read_from_followers=true");


### PR DESCRIPTION
sslmode is set to disabled by default. TLS can be enabled for postgres without a client cert, so it seems that we could use the default sslmode which is 'prefer' instead of disabling it outright. 


Test Plan: Run against a cluster with TLS enabled but no client sort, verify connectivity works.