### PR TITLE
[WIP] SqlGeoPartitioned App must now work with Tablespaces

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -192,4 +192,13 @@ public class AppConfig {
 
   // Determines whether we should output JSON metrics in addition to human-readable metrics.
   public boolean outputJsonMetrics = false;
+
+  // Tablespaces to be used for the SqlGeoPartitionedTable workload.
+  public String[] tablespaces;
+
+  // Placement policies to be used for the SqlGeoPartitionedTable workload.
+  public String[] placementPolicies;
+
+  // Replication factor to be used for the SqlGeoPartitionedTable workload.
+  public int replicationFactor;
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -45,6 +45,8 @@ public class SqlGeoPartitionedTable extends AppBase {
     // The number of unique keys to write. This determines the number of inserts (as opposed to
     // updates).
     appConfig.numUniqueKeysToWrite = NUM_UNIQUE_KEYS;
+    // Replication factor to use for the tablespaces being created for the test.
+    appConfig.replicationFactor = 1;
   }
 
   // The default table name to create and use for CRUD ops.
@@ -85,6 +87,37 @@ public class SqlGeoPartitionedTable extends AppBase {
         LOG.info("Dropping any table(s) left from previous runs if any");
       }
 
+      // Create tablespaces if necessary.
+      if (appConfig.placementPolicies != null) {
+        appConfig.tablespaces = new String[appConfig.numPartitions];
+        for (int i = 0; i < appConfig.numPartitions; i++) {
+          // Placement policy is of the type cloud.region.zone.
+          // Split it into individual entities.
+          final String placement = appConfig.placementPolicies[i];
+          final String[] entities = placement.split("\\.");
+
+          if (entities.length != 3) {
+            LOG.error(String.format("Invalid placement info %s. It should " +
+                                    "be of the form cloud.region.zone", placement));
+            System.exit(1);
+          }
+
+          String tablespaceName = "tablespace" + String.valueOf(i);
+
+          statement.execute(" CREATE TABLESPACE " + tablespaceName +
+            "  WITH (replica_placement=" +
+            "'{\"num_replicas\":" + appConfig.replicationFactor +
+            ", \"placement_blocks\":[" +
+            "{\"cloud\":\"" + entities[0] + "\"," +
+            "\"region\":\"" + entities[1] + "\"," +
+            "\"zone\":\"" + entities[2] + "\"," +
+            "\"min_num_replicas\":" + appConfig.replicationFactor + "}]}')");
+
+          // Add to the set of tablespaces to be used by the test.
+          appConfig.tablespaces[i] = tablespaceName;
+        }
+      }
+
       // TODO Creating the primary keys on each partition because of issue #6149.
       statement.execute(
           String.format("CREATE TABLE IF NOT EXISTS %s (region text, k text, v text) " +
@@ -94,8 +127,8 @@ public class SqlGeoPartitionedTable extends AppBase {
         statement.execute(
             String.format("CREATE TABLE IF NOT EXISTS %1$s_%2$d PARTITION OF %1$s (" +
                               "region, k, v, PRIMARY KEY((region, k) HASH))" +
-                              " FOR VALUES IN ('region_%2$d')",
-                          getTableName(), i));
+                              " FOR VALUES IN ('region_%2$d') TABLESPACE %3$s",
+                          getTableName(), i, appConfig.tablespaces[i]));
       }
 
       LOG.info(String.format("Created (if not exists) table: %s", getTableName()));
@@ -207,7 +240,10 @@ public class SqlGeoPartitionedTable extends AppBase {
         "Sample app based on SqlInserts but uses a geo-partitioned table.",
         "It creates a list-partitioned table with an additional primary-key column ",
         "'region', and a configurable number of partitions.",
-        "The value(s) for the new column (region) is automatically generated for each",
+        "Each partition is placed in a separate tablespace. These tablespaces can be ",
+        "pre-created and provided with the --tablespaces option or they can be ",
+        "created within the app itself based on the --placement_policies option.",
+        "The value(s) for the column (region) is automatically generated for each",
         "read/write operation based on the randomly-generated key column ('k').");
   }
 
@@ -215,6 +251,9 @@ public class SqlGeoPartitionedTable extends AppBase {
   public List<String> getWorkloadOptionalArguments() {
     return Arrays.asList(
         "--num_partitions " + appConfig.numPartitions,
+        "--tablespaces " + appConfig.tablespaces,
+        "--replication_factor " + appConfig.replicationFactor,
+        "--placement_policies " + appConfig.placementPolicies,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -376,15 +376,80 @@ public class CmdLineOpts {
     }
 
     if (appName.equals(SqlGeoPartitionedTable.class.getSimpleName())) {
+      // Find the number of partitions to be used by the app.
       if (commandLine.hasOption("num_partitions")) {
         AppBase.appConfig.numPartitions =
                 Integer.parseInt(commandLine.getOptionValue("num_partitions"));
       }
       LOG.info(String.format("SqlGeoPartitionedTable: will use %d partitions",
                              AppBase.appConfig.numPartitions));
+
+      // Either --tablespaces or --placement_policies has to be set.
+      if (!commandLine.hasOption("tablespaces") &&
+          !commandLine.hasOption("placement_policies")) {
+
+        LOG.error("Either --tablespaces or --placement_policies has to be set");
+        System.exit(1);
+      }
+
+      // Check if the tablespaces to be used for the app have already been specified.
+      if (commandLine.hasOption("tablespaces")) {
+        AppBase.appConfig.tablespaces = commandLine.getOptionValue("tablespaces").split(",");
+
+        // Each partition should be placed in a separate tablespace. Verify that number of
+        // tablespaces matches the number of partitions.
+        if (AppBase.appConfig.tablespaces.length != AppBase.appConfig.numPartitions) {
+          LOG.error(String.format("The number of tablespaces %d does not match the number of partitions",
+                    AppBase.appConfig.tablespaces.length));
+          System.exit(1);
+        }
+      }
+
+      if (commandLine.hasOption("placement_policies")) {
+        // Verify that --tablespaces has not already been set.
+        if (commandLine.hasOption("tablespaces")) {
+          LOG.error("Invalid input: Both --tablespaces and --placement_policies set. Either " +
+                    "specify --tablespaces if they have already been created. Use " +
+                    "--placement_policies if tablespaces need to be created by the app.");
+          System.exit(1);
+        }
+
+        AppBase.appConfig.placementPolicies =
+          commandLine.getOptionValue("placement_policies").split(",");
+
+        // Verify that the number of placement_policies matches the number of partitions.
+        if (AppBase.appConfig.placementPolicies.length != AppBase.appConfig.numPartitions) {
+          LOG.error(String.format("The number of placement_policies %d does not match the number of partitions",
+                    AppBase.appConfig.numPartitions));
+          System.exit(1);
+        }
+
+        // Verify that --placement_policies is well formed.
+        for (int i = 0; i < AppBase.appConfig.numPartitions; i++) {
+          // Placement policy is of the type cloud.region.zone.
+          // Split it into individual entities.
+          final String placement = AppBase.appConfig.placementPolicies[i];
+          final String[] entities = placement.split("\\.");
+
+          if (entities.length != 3) {
+            LOG.error(String.format("Placement policy %s is not valid. " +
+                                    "It must be of the form cloud.region.zone",
+                                    placement));
+            System.exit(1);
+          }
+        }
+      }
+
+      if (commandLine.hasOption("replication_factor")) {
+        AppBase.appConfig.replicationFactor =
+          Integer.parseInt(commandLine.getOptionValue("replication_factor"));
+        if (AppBase.appConfig.replicationFactor <= 0) {
+          LOG.error(String.format("Invalid value for replication_factor %d, expected a positive value",
+                                  AppBase.appConfig.replicationFactor));
+          System.exit(1);
+        }
+      }
     }
-
-
   }
 
   /**
@@ -789,6 +854,21 @@ public class CmdLineOpts {
 
     options.addOption("num_partitions", true,
                       "[SqlGeoPartitionedTable] Number of partitions to create.");
+
+    options.addOption("tablespaces", true,
+                      "[SqlGeoPartitionedTable] Comma separated list of Tablespaces " +
+                      "to be used for each partition. Number of tablespaces must match " +
+                      "num_partitions.");
+
+    options.addOption("placement_policies", true,
+                      "[SqlGeoPartitionedTable] Comma separated list of placement policies " +
+                      "to be used to create a tablespace for each partition. This option should " +
+                      "not be used along with --tablespaces");
+
+    options.addOption("replication_factor", true,
+                      "[SqlGeoPartitionedTable] Replication factor to be used to create a " +
+                      "tablespace for each partition. This option should not be used along " +
+                      "with --tablespaces");
 
     // First check if a "--help" argument is passed with a simple parser. Note that if we add
     // required args, then the help string would not work. See:


### PR DESCRIPTION
This patch modifies SqlGeoPartitioned workflow to use tablespaces. Now the app will associate each partition with a tablespace
It introduces 3 new options. Either the input provides:
--tablespaces : A new flag that provides a comma separated string with list of tablespaces to be used by the app.
(or)
--replication_factor and --placement_policies. The former specifies the RF for each tablespace. The latter is a comma separated list of cloud.region.zone strings. Each cloud.region.zone will be used to create a tablespace.