### PR TITLE
Fix URL for download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The workloads here have drivers compatible with the above and emulate a number o
 
 Download yb-sample-apps JAR
 ```
-$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.7/yb-sample-apps.jar
+$ wget https://github.com/yugabyte/yb-sample-apps/releases/download/1.3.7/yb-sample-apps-1.3.7.jar
 ```
 
 For help, simply run the following:


### PR DESCRIPTION
@kmuthukk reported the download link not working.

This PR appends the version to the jar name.