### PR TITLE
Fixes a race condition between a getter method and reset/destroy methods

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -820,20 +820,23 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   }
 
   public SimpleLoadGenerator getSimpleLoadGenerator() {
-    if (simpleLoadGenerator == null) {
+    SimpleLoadGenerator sLoadGeneratorTmp = simpleLoadGenerator;
+    if (sLoadGeneratorTmp == null) {
       synchronized (AppBase.class) {
         if (simpleLoadGenerator == null) {
           simpleLoadGenerator = new SimpleLoadGenerator(0,
               appConfig.numUniqueKeysToWrite,
               appConfig.maxWrittenKey);
         }
+        sLoadGeneratorTmp = simpleLoadGenerator;
       }
     }
-    return simpleLoadGenerator;
+    return sLoadGeneratorTmp;
   }
 
   public RedisHashLoadGenerator getRedisHashLoadGenerator() {
-    if (redisHashLoadGenerator == null) {
+    RedisHashLoadGenerator redisHashLoadGeneratorTmp = redisHashLoadGenerator;
+    if (redisHashLoadGeneratorTmp == null) {
       synchronized (AppBase.class) {
         if (redisHashLoadGenerator == null) {
           redisHashLoadGenerator = new RedisHashLoadGenerator(appConfig.uuid,
@@ -841,9 +844,10 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
               appConfig.keyUpdateFreqZipfExponent, appConfig.subkeyUpdateFreqZipfExponent,
               appConfig.numSubkeysPerWrite, appConfig.numSubkeysPerRead);
         }
+        redisHashLoadGeneratorTmp = redisHashLoadGenerator;
       }
     }
-    return redisHashLoadGenerator;
+    return redisHashLoadGeneratorTmp;
   }
 
   public static long numOps() {

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
@@ -129,7 +129,8 @@ public class CassandraBatchTimeseries extends AppBase {
   }
 
   private PreparedStatement getPreparedInsert()  {
-    if (preparedInsert == null) {
+    PreparedStatement pInsertTmp = preparedInsert;
+    if (pInsertTmp == null) {
       synchronized (prepareInitLock) {
         if (preparedInsert == null) {
           // Create the prepared statement object.
@@ -137,13 +138,15 @@ public class CassandraBatchTimeseries extends AppBase {
                                              "(:metric_id, :ts, :value);", getTableName());
           preparedInsert = getCassandraClient().prepare(insert_stmt);
         }
+        pInsertTmp = preparedInsert;
       }
     }
-    return preparedInsert;
+    return pInsertTmp;
   }
 
   private PreparedStatement getPreparedSelect()  {
-    if (preparedSelect == null) {
+    PreparedStatement pSelectTmp = preparedSelect;
+    if (pSelectTmp == null) {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           // Create the prepared statement object.
@@ -152,9 +155,10 @@ public class CassandraBatchTimeseries extends AppBase {
                                              "LIMIT :readBatchSize;", getTableName());
           preparedSelect = getCassandraClient().prepare(select_stmt);
         }
+        pSelectTmp = preparedSelect;
       }
     }
-    return preparedSelect;
+    return pSelectTmp;
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
@@ -117,7 +117,8 @@ public class CassandraEventData extends AppBase {
 	}
 
 	private PreparedStatement getPreparedInsert() {
-		if (preparedInsert == null) {
+		PreparedStatement pInsertTmp = preparedInsert;
+		if (pInsertTmp == null) {
 			synchronized (prepareInitLock) {
 				if (preparedInsert == null) {
 					// Create the prepared statement object.
@@ -125,13 +126,15 @@ public class CassandraEventData extends AppBase {
 							+ "(:device_id, :ts, :event_type, :value);", getTableName());
 					preparedInsert = getCassandraClient().prepare(insert_stmt);
 				}
+				pInsertTmp = preparedInsert;
 			}
 		}
-		return preparedInsert;
+		return pInsertTmp;
 	}
 
 	private PreparedStatement getPreparedSelect() {
-		if (preparedSelect == null) {
+		PreparedStatement pSelectTmp = preparedSelect;
+		if (pSelectTmp == null) {
 			synchronized (prepareInitLock) {
 				if (preparedSelect == null) {
 					// Create the prepared statement object.
@@ -140,9 +143,10 @@ public class CassandraEventData extends AppBase {
 							+ "LIMIT :readBatchSize;", getTableName());
 					preparedSelect = getCassandraClient().prepare(select_stmt);
 				}
+				pSelectTmp = preparedSelect;
 			}
 		}
-		return preparedSelect;
+		return pSelectTmp;
 	}
 
 	@Override

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -54,7 +54,8 @@ public abstract class CassandraKeyValueBase extends AppBase {
   }
 
   protected PreparedStatement getPreparedSelect(String selectStmt, boolean localReads)  {
-    if (preparedSelect == null) {
+    PreparedStatement preparedSelectLocal = preparedSelect;
+    if (preparedSelectLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           // Create the prepared statement object.
@@ -64,9 +65,10 @@ public abstract class CassandraKeyValueBase extends AppBase {
             preparedSelect.setConsistencyLevel(ConsistencyLevel.ONE);
           }
         }
+        preparedSelectLocal = preparedSelect;
       }
     }
-    return preparedSelect;
+    return preparedSelectLocal;
   }
 
   protected abstract String getDefaultTableName();
@@ -129,15 +131,17 @@ public abstract class CassandraKeyValueBase extends AppBase {
   }
 
   protected PreparedStatement getPreparedInsert(String insertStmt)  {
+    PreparedStatement preparedInsertLocal = preparedInsert;
     if (preparedInsert == null) {
       synchronized (prepareInitLock) {
         if (preparedInsert == null) {
           // Create the prepared statement object.
           preparedInsert = getCassandraClient().prepare(insertStmt);
         }
+        preparedInsertLocal = preparedInsert;
       }
     }
-    return preparedInsert;
+    return preparedInsertLocal;
   }
 
   protected abstract BoundStatement bindInsert(String key, ByteBuffer value);

--- a/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
@@ -134,15 +134,17 @@ public class CassandraPersonalization extends AppBase {
   }
 
   protected PreparedStatement getPreparedSelect(String selectStmt)  {
-    if (preparedSelect == null) {
+    PreparedStatement preparedSelectLocal = preparedSelect;
+    if (preparedSelectLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           // Create the prepared statement object.
           preparedSelect = getCassandraClient().prepare(selectStmt);
         }
+        preparedSelectLocal = preparedSelect;
       }
     }
-    return preparedSelect;
+    return preparedSelectLocal;
   }
 
   private PreparedStatement getPreparedSelect()  {
@@ -169,15 +171,17 @@ public class CassandraPersonalization extends AppBase {
   }
 
   protected PreparedStatement getPreparedInsert(String insertStmt)  {
-    if (preparedInsert == null) {
+    PreparedStatement preparedInsertLocal = preparedInsert;
+    if (preparedInsertLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsert == null) {
           // Create the prepared statement object.
           preparedInsert = getCassandraClient().prepare(insertStmt);
         }
+        preparedInsertLocal = preparedInsert;
       }
     }
-    return preparedInsert;
+    return preparedInsertLocal;
   }
 
   protected PreparedStatement getPreparedInsert()  {

--- a/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
@@ -142,7 +142,8 @@ public class CassandraStockTicker extends AppBase {
   }
 
   private PreparedStatement getPreparedSelectLatest()  {
-    if (preparedSelectLatest == null) {
+    PreparedStatement pSelectLatestTmp = preparedSelectLatest;
+    if (pSelectLatestTmp == null) {
       synchronized (prepareInitLock) {
         if (preparedSelectLatest == null) {
           // Create the prepared statement object.
@@ -150,9 +151,10 @@ public class CassandraStockTicker extends AppBase {
               String.format("SELECT * from %s WHERE ticker_id = ? LIMIT 1", tickerTableRaw);
           preparedSelectLatest = getCassandraClient().prepare(select_stmt);
         }
+        pSelectLatestTmp = preparedSelectLatest;
       }
     }
-    return preparedSelectLatest;
+    return pSelectLatestTmp;
   }
 
   @Override
@@ -177,7 +179,8 @@ public class CassandraStockTicker extends AppBase {
   }
 
   private PreparedStatement getPreparedInsertRaw()  {
-    if (preparedInsertRaw == null) {
+    PreparedStatement preparedInsertRawLocal = preparedInsertRaw;
+    if (preparedInsertRawLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsertRaw == null) {
           // Create the prepared statement object.
@@ -186,13 +189,15 @@ public class CassandraStockTicker extends AppBase {
                             tickerTableRaw);
           preparedInsertRaw = getCassandraClient().prepare(insert_stmt);
         }
+        preparedInsertRawLocal = preparedInsertRaw;
       }
     }
-    return preparedInsertRaw;
+    return preparedInsertRawLocal;
   }
 
   private PreparedStatement getPreparedInsertMin()  {
-    if (preparedInsertMin == null) {
+    PreparedStatement preparedInsertMinLocal = preparedInsertMin;
+    if (preparedInsertMinLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsertMin == null) {
           // Create the prepared statement object.
@@ -201,9 +206,10 @@ public class CassandraStockTicker extends AppBase {
                             tickerTableMin);
           preparedInsertMin = getCassandraClient().prepare(insert_stmt);
         }
+        preparedInsertMinLocal = preparedInsertMin;
       }
     }
-    return preparedInsertMin;
+    return preparedInsertMinLocal;
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
@@ -161,7 +161,8 @@ public class CassandraTimeseries extends AppBase {
   }
 
   private PreparedStatement getPreparedSelect()  {
-    if (preparedSelect == null) {
+    PreparedStatement pSelectTmp = preparedSelect;
+    if (pSelectTmp == null) {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           // Create the prepared statement object.
@@ -173,9 +174,10 @@ public class CassandraTimeseries extends AppBase {
                             getTableName());
           preparedSelect = getCassandraClient().prepare(select_stmt);
         }
+        pSelectTmp = preparedSelect;
       }
     }
-    return preparedSelect;
+    return pSelectTmp;
   }
 
   @Override
@@ -247,7 +249,8 @@ public class CassandraTimeseries extends AppBase {
   }
 
   private PreparedStatement getPreparedInsert()  {
-    if (preparedInsert == null) {
+    PreparedStatement preparedInsertLocal = preparedInsert;
+    if (preparedInsertLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsert == null) {
           // Create the prepared statement object.
@@ -257,9 +260,10 @@ public class CassandraTimeseries extends AppBase {
                             getTableName());
           preparedInsert = getCassandraClient().prepare(insert_stmt);
         }
+        preparedInsertLocal = preparedInsert;
       }
     }
-    return preparedInsert;
+    return preparedInsertLocal;
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -146,7 +146,8 @@ public class SqlForeignKeysAndJoins extends AppBase {
   }
 
   private PreparedStatement getPreparedSelect() throws Exception {
-    if (preparedSelect == null) {
+    PreparedStatement preparedSelectLocal = preparedSelect;
+    if (preparedSelectLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           preparedSelect = getPostgresConnection().prepareStatement(
@@ -156,9 +157,10 @@ public class SqlForeignKeysAndJoins extends AppBase {
                             "LIMIT 10;", getTable1Name(), getTable2Name(),
                             getTable1Name(), getTable1Name(), getTable2Name()));
         }
+        preparedSelectLocal = preparedSelect;
       }
     }
-    return preparedSelect;
+    return preparedSelectLocal;
   }
 
   @Override
@@ -207,7 +209,8 @@ public class SqlForeignKeysAndJoins extends AppBase {
   }
 
   private PreparedStatement getPreparedInsertUser() throws Exception {
-    if (preparedInsertUser == null) {
+    PreparedStatement preparedInsertUserLocal = preparedInsertUser;
+    if (preparedInsertUserLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsertUser == null) {
           String stmt = String.format("INSERT INTO %s (user_id, user_details) VALUES (?, ?);", getTable1Name());
@@ -215,13 +218,15 @@ public class SqlForeignKeysAndJoins extends AppBase {
             preparedInsertUser = getPostgresConnection().prepareStatement(stmt);
           }
         }
+        preparedInsertUserLocal = preparedInsertUser;
       }
     }
-    return preparedInsertUser;
+    return preparedInsertUserLocal;
   }
 
   private PreparedStatement getPreparedInsertUserOrder() throws Exception {
-    if (preparedInsertOrder == null) {
+    PreparedStatement preparedInsertOrderLocal = preparedInsertOrder;
+    if (preparedInsertOrderLocal == null) {
       synchronized (prepareInitLock) {
         if (preparedInsertOrder == null) {
           String stmt = String.format("INSERT INTO %s (user_id, order_time, order_details) VALUES (?, ?, ?);", 
@@ -232,9 +237,10 @@ public class SqlForeignKeysAndJoins extends AppBase {
             preparedInsertOrder = connection.prepareStatement(stmt);
           }
         }
+        preparedInsertOrderLocal = preparedInsertOrder;
       }
     }
-    return preparedInsertOrder;
+    return preparedInsertOrderLocal;
   }
 
   @Override


### PR DESCRIPTION
Using a local reference object to avoid possible race conditions between different threads trying to create preparedInserts, preparedSelects etc and the resetClients and destroyClients methods.