### PR TITLE
Setting number of unique keys equal to the number of writes in case both are unequal

### DIFF
--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -89,7 +89,7 @@ public class CmdLineOpts {
   // Command line opts parser.
   CommandLine commandLine;
 
-  public void initialize(CommandLine commandLine) throws ClassNotFoundException,IllegalArgumentException {
+  public void initialize(CommandLine commandLine) throws ClassNotFoundException {
     this.commandLine = commandLine;
     if (commandLine.hasOption("uuid")) {
       loadTesterUUID = UUID.fromString(commandLine.getOptionValue("uuid"));

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -89,7 +89,7 @@ public class CmdLineOpts {
   // Command line opts parser.
   CommandLine commandLine;
 
-  public void initialize(CommandLine commandLine) throws ClassNotFoundException {
+  public void initialize(CommandLine commandLine) throws ClassNotFoundException,IllegalArgumentException {
     this.commandLine = commandLine;
     if (commandLine.hasOption("uuid")) {
       loadTesterUUID = UUID.fromString(commandLine.getOptionValue("uuid"));
@@ -511,6 +511,11 @@ public class CmdLineOpts {
       AppBase.appConfig.numUniqueKeysToWrite =
           Long.parseLong(cmd.getOptionValue("num_unique_keys"));
     }
+    if(AppBase.appConfig.numKeysToWrite != AppBase.appConfig.numUniqueKeysToWrite){
+      AppBase.appConfig.numUniqueKeysToWrite = AppBase.appConfig.numKeysToWrite;
+      LOG.warn(String.format("Setting number of numUniqueKeysToWrite equal to the numKeysToWrite, num_unique_keys = %d",AppBase.appConfig.numUniqueKeysToWrite));
+    }
+
     AppBase.appConfig.maxWrittenKey = Long.parseLong(cmd.getOptionValue("max_written_key",
         String.valueOf(AppBase.appConfig.maxWrittenKey)));
     if (cmd.hasOption("value_size")) {


### PR DESCRIPTION
Fixed: https://github.com/yugabyte/yugabyte-db/issues/8416

Test plan: 
- Validated if a number of unique keys less than a number of writes then setting a number of unique keys equal to the number of writes.

<img width="1764" alt="Screenshot 2021-06-28 at 11 19 39 AM" src="https://user-images.githubusercontent.com/79436143/123586753-d4673580-d802-11eb-87c8-9c3c96d2fa89.png">
