### PR TITLE
Drop YSQL tables only if they don't exist

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -73,7 +73,7 @@ public class SqlDataLoad extends AppBase {
     @Override
     public void dropTable() throws Exception {
       try (Connection connection = getPostgresConnection()) {
-        connection.createStatement().execute("DROP TABLE " + getTableName());
+        connection.createStatement().execute("DROP TABLE IF EXISTS " + getTableName());
         LOG.info(String.format("Dropped table: %s", getTableName()));
         for (int i = 1; i <= appConfig.numForeignKeys; i++) {
             String fkName = getFkTableName(i);

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -71,7 +71,7 @@ public class SqlGeoPartitionedTable extends AppBase {
   @Override
   public void dropTable() throws Exception {
     try (Connection connection = getPostgresConnection()) {
-      connection.createStatement().execute("DROP TABLE " + getTableName());
+      connection.createStatement().execute("DROP TABLE IF EXISTS " + getTableName());
       LOG.info(String.format("Dropped table: %s", getTableName()));
     }
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -71,7 +71,7 @@ public class SqlInserts extends AppBase {
   @Override
   public void dropTable() throws Exception {
     try (Connection connection = getPostgresConnection()) {
-      connection.createStatement().execute("DROP TABLE " + getTableName());
+      connection.createStatement().execute("DROP TABLE IF EXISTS " + getTableName());
       LOG.info(String.format("Dropped table: %s", getTableName()));
     }
   }


### PR DESCRIPTION
Fixed couple apps so that they will only try to drop tables if they don't already exist. This was causing issues with repeated runs of yb-sample-apps.