### PR TITLE
Integrated the jdbc smart driver with Sql* sample apps.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,12 @@
     <dependency>
       <groupId>com.yugabyte</groupId>
       <artifactId>jdbc-yugabytedb</artifactId>
-      <version>42.2.7-yb-5-beta.5</version>
+      <version>42.3.0-beta.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.2.18</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
       <version>2.8.0</version>
     </dependency>
     <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <version>42.2.18</version>
+      <groupId>com.yugabyte</groupId>
+      <artifactId>jdbc-yugabytedb</artifactId>
+      <version>42.2.7-yb-5-beta.5</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -188,7 +188,15 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         }
         if (smartDriver) {
           props.setProperty("load-balance", String.valueOf(appConfig.loadBalance));
+          if (appConfig.topologyKeys != null) {
+            props.setProperty("topology-keys", appConfig.topologyKeys);
+          }
         }
+
+        if (appConfig.enableDriverDebug) {
+          props.setProperty("loggerLevel", "debug");
+        }
+
         if (password != null) {
           props.setProperty("password", password);
         }

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -184,7 +184,6 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         ContactPoint contactPoint = getRandomContactPoint();
         Properties props = new Properties();
         props.setProperty("user", username);
-        // Check if the smart driver is there in the class path
         if (isLoadBalanceOn) {
           props.setProperty("load-balance", String.valueOf(appConfig.loadBalance));
           if (appConfig.topologyKeys != null) {

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -179,6 +179,16 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         ContactPoint contactPoint = getRandomContactPoint();
         Properties props = new Properties();
         props.setProperty("user", username);
+        // Check if the smart driver is there in the class path
+        boolean smartDriver = true;
+        try {
+          Class.forName("com.yugabyte.ysql.ClusterAwareLoadBalancer");
+        } catch (ClassNotFoundException cnfe) {
+          smartDriver = false;
+        }
+        if (smartDriver) {
+          props.setProperty("load-balance", String.valueOf(appConfig.loadBalance));
+        }
         if (password != null) {
           props.setProperty("password", password);
         }

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -194,6 +194,9 @@ public class AppConfig {
   // Configurations for SqlGeoPartitionedTable workload.
   public int numPartitions = 2;
 
+  // Configuration for setting load-balance in  Sql* workload.
+  public boolean loadBalance = true;
+
   // Determines whether we should output JSON metrics in addition to human-readable metrics.
   public boolean outputJsonMetrics = false;
 

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -197,6 +197,12 @@ public class AppConfig {
   // Configuration for setting load-balance in  Sql* workload.
   public boolean loadBalance = true;
 
+  // Configuration for setting topology-keys in  Sql* workload.
+  public String topologyKeys = null;
+
+  // Configuration for setting topology-keys in  Sql* workload.
+  public boolean enableDriverDebug = false;
+
   // Determines whether we should output JSON metrics in addition to human-readable metrics.
   public boolean outputJsonMetrics = false;
 

--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -312,6 +312,7 @@ public class SqlDataLoad extends AppBase {
                 "--num_foreign_key_table_rows " + appConfig.numForeignKeyTableRows,
                 "--num_consecutive_rows_with_same_fk " + appConfig.numConsecutiveRowsWithSameFk,
                 "--batch_size " + appConfig.batchSize,
-                "--num_threads_write " + appConfig.numWriterThreads);
+                "--num_threads_write " + appConfig.numWriterThreads,
+                "--load_balance " + appConfig.loadBalance);
     }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -313,6 +313,8 @@ public class SqlDataLoad extends AppBase {
                 "--num_consecutive_rows_with_same_fk " + appConfig.numConsecutiveRowsWithSameFk,
                 "--batch_size " + appConfig.batchSize,
                 "--num_threads_write " + appConfig.numWriterThreads,
-                "--load_balance " + appConfig.loadBalance);
+                "--load_balance " + appConfig.loadBalance,
+                "--topology_keys " + appConfig.topologyKeys,
+                "--debug-driver " + appConfig.enableDriverDebug);
     }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -315,6 +315,6 @@ public class SqlDataLoad extends AppBase {
                 "--num_threads_write " + appConfig.numWriterThreads,
                 "--load_balance " + appConfig.loadBalance,
                 "--topology_keys " + appConfig.topologyKeys,
-                "--debug-driver " + appConfig.enableDriverDebug);
+                "--debug_driver " + appConfig.enableDriverDebug);
     }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -16,6 +16,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -121,7 +122,7 @@ public class SqlForeignKeysAndJoins extends AppBase {
                           "  FOREIGN KEY (user_id) REFERENCES %s (user_id)" +
                           ");", getTable2Name(), getTable1Name()));
         LOG.info(String.format("Created table: %s", getTable2Name()));
-      } catch (org.postgresql.util.PSQLException e) {
+      } catch (SQLException e) {
         LOG.error("Failed to create tables", e);
         System.err.println("\n================================================");
         System.err.println("If you hit the following:");

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -328,6 +328,8 @@ public class SqlForeignKeysAndJoins extends AppBase {
         "--num_threads_write " + appConfig.numWriterThreads,
         "--username " + "<DB USERNAME>",
         "--password " + "<OPTIONAL PASSWORD>",
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -327,7 +327,7 @@ public class SqlForeignKeysAndJoins extends AppBase {
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
         "--username " + "<DB USERNAME>",
-        "--password " + "<OPTIONAL PASSWORD>"
-        );
+        "--password " + "<OPTIONAL PASSWORD>",
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -259,6 +259,7 @@ public class SqlGeoPartitionedTable extends AppBase {
         "--num_threads_write " + appConfig.numWriterThreads,
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,
-        "--num_writes " + appConfig.numKeysToWrite);
+        "--num_writes " + appConfig.numKeysToWrite,
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -260,6 +260,8 @@ public class SqlGeoPartitionedTable extends AppBase {
         "--num_unique_keys " + appConfig.numUniqueKeysToWrite,
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -205,6 +205,8 @@ public class SqlInserts extends AppBase {
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -204,6 +204,7 @@ public class SqlInserts extends AppBase {
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
-        "--num_threads_write " + appConfig.numWriterThreads);
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
@@ -204,6 +204,8 @@ public class SqlSecondaryIndex extends AppBase {
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSecondaryIndex.java
@@ -203,6 +203,7 @@ public class SqlSecondaryIndex extends AppBase {
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
-        "--num_threads_write " + appConfig.numWriterThreads);
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -200,6 +200,8 @@ public class SqlSnapshotTxns extends AppBase {
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -199,6 +199,7 @@ public class SqlSnapshotTxns extends AppBase {
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
-        "--num_threads_write " + appConfig.numWriterThreads);
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -209,6 +209,7 @@ public class SqlUpdates extends AppBase {
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
-        "--num_threads_write " + appConfig.numWriterThreads);
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--load_balance " + appConfig.loadBalance);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlUpdates.java
@@ -210,6 +210,8 @@ public class SqlUpdates extends AppBase {
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
-        "--load_balance " + appConfig.loadBalance);
+        "--load_balance " + appConfig.loadBalance,
+        "--topology_keys " + appConfig.topologyKeys,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -332,7 +332,12 @@ public class CmdLineOpts {
     if (commandLine.hasOption("load_balance")) {
       AppBase.appConfig.loadBalance = Boolean.valueOf(commandLine.getOptionValue("load_balance"));
     }
-
+    if (commandLine.hasOption("topology_keys")) {
+      AppBase.appConfig.topologyKeys = commandLine.getOptionValue("topology_keys");
+    }
+    if (commandLine.hasOption("debug_driver")) {
+      AppBase.appConfig.enableDriverDebug = Boolean.valueOf(commandLine.getOptionValue("debug_driver"));
+    }
     if (commandLine.hasOption("concurrent_clients")) {
       AppBase.appConfig.concurrentClients = Integer.parseInt(
           commandLine.getOptionValue("concurrent_clients"));
@@ -354,8 +359,21 @@ public class CmdLineOpts {
         AppBase.appConfig.loadBalance =
                 Boolean.parseBoolean(commandLine.getOptionValue("load_balance"));
       }
-      LOG.info(String.format(appName + " workload: using driver set for load-balance = "
-              + AppBase.appConfig.loadBalance));
+      if (commandLine.hasOption("topology_keys")) {
+        AppBase.appConfig.topologyKeys =
+                commandLine.getOptionValue("topology_keys");
+      }
+      String logMsg = String.format(appName + " workload: using driver set for load-balance = "
+              + AppBase.appConfig.loadBalance);
+      if (AppBase.appConfig.topologyKeys != null) {
+        logMsg = String.format(appName + " workload: using driver set for load-balance = "
+                + AppBase.appConfig.loadBalance + " with topology_keys = " + AppBase.appConfig.topologyKeys);
+      }
+      if (commandLine.hasOption("debug_driver")) {
+        AppBase.appConfig.enableDriverDebug =
+                Boolean.parseBoolean(commandLine.getOptionValue("debug_driver"));
+      }
+      LOG.info(logMsg);
     }
 
     if (appName.equals(SqlDataLoad.class.getSimpleName())) {
@@ -755,6 +773,10 @@ public class CmdLineOpts {
             "If this option is set, the --username option is required.");
     options.addOption("load_balance", true,
             "Set up YugabyteDB JDBC driver with in-built load balancing capability.");
+    options.addOption("topology_keys", true,
+            "Set up YugabyteDB JDBC driver with topology aware load balancing capability.");
+    options.addOption("debug_driver", true,
+            "Enable debug logs for YugabyteDB JDBC driver");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true,

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -329,6 +329,10 @@ public class CmdLineOpts {
       }
       AppBase.appConfig.dbPassword = commandLine.getOptionValue("password");
     }
+    if (commandLine.hasOption("load_balance")) {
+      AppBase.appConfig.loadBalance = Boolean.valueOf(commandLine.getOptionValue("load_balance"));
+    }
+
     if (commandLine.hasOption("concurrent_clients")) {
       AppBase.appConfig.concurrentClients = Integer.parseInt(
           commandLine.getOptionValue("concurrent_clients"));
@@ -343,6 +347,15 @@ public class CmdLineOpts {
     if (commandLine.hasOption("num_indexes")) {
       AppBase.appConfig.numIndexes =
           Integer.parseInt(commandLine.getOptionValue("num_indexes"));
+    }
+
+    if (appName.startsWith("Sql")) {
+      if (commandLine.hasOption("load_balance")) {
+        AppBase.appConfig.loadBalance =
+                Boolean.parseBoolean(commandLine.getOptionValue("load_balance"));
+      }
+      LOG.info(String.format(appName + " workload: using driver set for load-balance = "
+              + AppBase.appConfig.loadBalance));
     }
 
     if (appName.equals(SqlDataLoad.class.getSimpleName())) {
@@ -740,6 +753,8 @@ public class CmdLineOpts {
     options.addOption("password", true,
         "The password to use when connecting to the database. " +
             "If this option is set, the --username option is required.");
+    options.addOption("load_balance", true,
+            "Set up YugabyteDB JDBC driver with in-built load balancing capability  ");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true,

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -754,7 +754,7 @@ public class CmdLineOpts {
         "The password to use when connecting to the database. " +
             "If this option is set, the --username option is required.");
     options.addOption("load_balance", true,
-            "Set up YugabyteDB JDBC driver with in-built load balancing capability  ");
+            "Set up YugabyteDB JDBC driver with in-built load balancing capability.");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true,


### PR DESCRIPTION
Added a command line option for Sql* workloads called '--load_balance'.
By default it will be 'true'. But can be switched off by providing _--load_balance false_ in the command line arg
Modified the pom.xml to point to Yugabyte JDBC driver.
Ran the Sql payloads and seems to be working as expected.