### PR TITLE
update code to honor the '--local_reads' flag

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValue.java
@@ -64,15 +64,7 @@ public class CassandraKeyValue extends CassandraKeyValueBase {
 
   @Override
   protected BoundStatement bindSelect(String key)  {
-    PreparedStatement prepared_stmt = getPreparedSelect(
-        String.format("SELECT k, v FROM %s WHERE k = ?;", getTableName()));
-    BoundStatement boundStmt = prepared_stmt.bind(key);
-    if (appConfig.localReads) {
-      LOG.debug("Doing local reads");
-      boundStmt.setConsistencyLevel(ConsistencyLevel.ONE);
-    }
-
-    return boundStmt;
+    return getPreparedSelect(String.format("SELECT k, v FROM %s WHERE k = ?;", getTableName())).bind(key);
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -60,7 +60,12 @@ public abstract class CassandraKeyValueBase extends AppBase {
       synchronized (prepareInitLock) {
         if (preparedSelect == null) {
           // Create the prepared statement object.
-          preparedSelect = getCassandraClient().prepare(selectStmt);
+          SimpleStatementBuilder builder = new SimpleStatementBuilder(selectStmt);
+          if (appConfig.localReads) {
+            LOG.debug("Doing local reads");
+            builder.setConsistencyLevel(ConsistencyLevel.ONE);
+          }
+          preparedSelect = getCassandraClient().prepare(builder.build());
         }
         preparedSelectLocal = preparedSelect;
       }


### PR DESCRIPTION
The current `setConsistency` level for the local reads at the bound statement returns a new instance that's not assigned back. So the consistency level setting is forever lost. Moving that logic to the prepared stmt.