### PR TITLE
Allow YSQL connections with cert only

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -41,6 +41,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 import com.yugabyte.sample.common.metrics.Observation;
+import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 import com.datastax.driver.core.Cluster;
@@ -302,6 +303,9 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         }
         builder = builder
             .withCredentials(appConfig.dbUsername, appConfig.dbPassword);
+      }
+      if (appConfig.enableDriverDebug) {
+        Logger.getLogger("com.datastax.driver").setLevel(Level.DEBUG);
       }
       if (appConfig.sslCert != null) {
         builder = builder

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -205,10 +205,11 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         }
 
         if (appConfig.sslCert != null && appConfig.sslCert.length() > 0) {
-          assert(appConfig.sslKey != null && appConfig.sslKey.length() > 0) : "The SSL key is empty.";
           props.put("sslmode", "require");
           props.put("sslcert", appConfig.sslCert);
-          props.put("sslkey", appConfig.sslKey);
+          if (appConfig.sslKey != null && appConfig.sslKey.length() > 0) {
+            props.put("sslkey", appConfig.sslKey);
+          }
         }
 
         String url = isLoadBalanceOn ? "jdbc:yugabytedb:" : "jdbc:postgresql:";

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchKeyValue.java
@@ -96,6 +96,7 @@ public class CassandraBatchKeyValue extends CassandraKeyValue {
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,
       "--batch_size " + appConfig.batchSize,
-      "--table_ttl_seconds " + appConfig.tableTTLSeconds);
+      "--table_ttl_seconds " + appConfig.tableTTLSeconds,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraBatchTimeseries.java
@@ -312,6 +312,7 @@ public class CassandraBatchTimeseries extends AppBase {
       "--max_metrics_count " + max_metrics_count,
       "--table_ttl_seconds " + appConfig.tableTTLSeconds,
       "--batch_size " + appConfig.batchSize,
-      "--read_batch_size " + appConfig.cassandraReadBatchSize);
+      "--read_batch_size " + appConfig.cassandraReadBatchSize,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraEventData.java
@@ -297,6 +297,7 @@ public class CassandraEventData extends AppBase {
 				"--num_threads_write " + appConfig.numWriterThreads, "--num_devices " + appConfig.num_devices,
 				"--num_event_types " + appConfig.num_event_types, "--table_ttl_seconds " + appConfig.tableTTLSeconds,
 				"--batch_size " + appConfig.batchSize,
-				"--read_batch_size " + appConfig.cassandraReadBatchSize);
+				"--read_batch_size " + appConfig.cassandraReadBatchSize,
+				"--debug_driver " + appConfig.enableDriverDebug);
 	}
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraInserts.java
@@ -220,6 +220,7 @@ public class CassandraInserts extends CassandraKeyValue {
         "--num_threads_write " + appConfig.numWriterThreads,
         "--batch_size " + appConfig.batchSize,
         "--num_indexes" + appConfig.numIndexes,
-        "--value_size " + appConfig.valueSize);
+        "--value_size " + appConfig.valueSize,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -202,6 +202,7 @@ public abstract class CassandraKeyValueBase extends AppBase {
         "--value_size " + appConfig.valueSize,
         "--num_threads_read " + appConfig.numReaderThreads,
         "--num_threads_write " + appConfig.numWriterThreads,
-        "--table_ttl_seconds " + appConfig.tableTTLSeconds);
+        "--table_ttl_seconds " + appConfig.tableTTLSeconds,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraPersonalization.java
@@ -277,6 +277,7 @@ public class CassandraPersonalization extends AppBase {
       "--num_threads_write " + appConfig.numWriterThreads,
       "--num_stores " + appConfig.numStores,
       "--num_new_coupons_per_customer " + appConfig.numNewCouponsPerCustomer,
-      "--max_coupons_per_customer " + appConfig.maxCouponsPerCustomer);
+      "--max_coupons_per_customer " + appConfig.maxCouponsPerCustomer,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraSecondaryIndex.java
@@ -168,6 +168,7 @@ public class CassandraSecondaryIndex extends CassandraKeyValue {
       "--num_threads_read " + appConfig.numReaderThreads,
       "--num_threads_write " + appConfig.numWriterThreads,
       "--batch_write",
-      "--batch_size " + appConfig.batchSize);
+      "--batch_size " + appConfig.batchSize,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraStockTicker.java
@@ -327,6 +327,7 @@ public class CassandraStockTicker extends AppBase {
       "--num_threads_write " + appConfig.numWriterThreads,
       "--num_ticker_symbols " + num_ticker_symbols,
       "--data_emit_rate_millis " + data_emit_rate_millis,
-      "--table_ttl_seconds " + appConfig.tableTTLSeconds);
+      "--table_ttl_seconds " + appConfig.tableTTLSeconds,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTimeseries.java
@@ -395,6 +395,7 @@ public class CassandraTimeseries extends AppBase {
       "--min_metrics_count " + min_metrics_count,
       "--max_metrics_count " + max_metrics_count,
       "--data_emit_rate_millis " + data_emit_rate_millis,
-      "--table_ttl_seconds " + appConfig.tableTTLSeconds);
+      "--table_ttl_seconds " + appConfig.tableTTLSeconds,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalKeyValue.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalKeyValue.java
@@ -163,6 +163,7 @@ public class CassandraTransactionalKeyValue extends CassandraKeyValue {
       "--num_writes " + appConfig.numKeysToWrite,
       "--value_size " + appConfig.valueSize,
       "--num_threads_read " + appConfig.numReaderThreads,
-      "--num_threads_write " + appConfig.numWriterThreads);
+      "--num_threads_write " + appConfig.numWriterThreads,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalRestartRead.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraTransactionalRestartRead.java
@@ -154,7 +154,8 @@ public class CassandraTransactionalRestartRead extends CassandraKeyValue {
         "--num_reads " + appConfig.numKeysToRead,
         "--num_writes " + appConfig.numKeysToWrite,
         "--num_threads_read " + appConfig.numReaderThreads,
-        "--num_threads_write " + appConfig.numWriterThreads);
+        "--num_threads_write " + appConfig.numWriterThreads,
+        "--debug_driver " + appConfig.enableDriverDebug);
   }
 
   protected void setupLoadBalancingPolicy(Cluster.Builder builder) {

--- a/src/main/java/com/yugabyte/sample/apps/CassandraUniqueSecondaryIndex.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraUniqueSecondaryIndex.java
@@ -67,6 +67,7 @@ public class CassandraUniqueSecondaryIndex extends CassandraSecondaryIndex {
       "--num_reads " + appConfig.numKeysToRead,
       "--num_writes " + appConfig.numKeysToWrite,
       "--num_threads_read " + appConfig.numReaderThreads,
-      "--num_threads_write " + appConfig.numWriterThreads);
+      "--num_threads_write " + appConfig.numWriterThreads,
+      "--debug_driver " + appConfig.enableDriverDebug);
   }
 }

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -776,7 +776,7 @@ public class CmdLineOpts {
     options.addOption("topology_keys", true,
             "Set up YugabyteDB JDBC driver with topology aware load balancing capability.");
     options.addOption("debug_driver", true,
-            "Enable debug logs for YugabyteDB JDBC driver");
+            "Enable debug logs for YugabyteDB YSQL and YCQL drivers");
     options.addOption("concurrent_clients", true,
         "The number of client connections to establish to each host in the YugaByte DB cluster.");
     options.addOption("ssl_cert", true,


### PR DESCRIPTION
Separated SSL key and cert YSQL driver configuration to allow for passing only the cert argument. 
Prior if a cert was passed without a key, the null key was erroneously used in the connection properties causing exceptions.