### PR TITLE
Upgrade postgresql jdbc to 42.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.2.18</version>
+      <version>42.5.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Fixes SQL generated in PgResultSet.refresh() to escape column identifiers so as to prevent SQL injection.

Previously, the column names for both key and data columns in the table were copied as-is into the generated
SQL. This allowed a malicious table with column names that include statement terminator to be parsed and
executed as multiple separate commands.

    CVE-2022-31197