### PR TITLE
display connection options (username, passowrd, ssl_cert) when printi…

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -682,6 +682,17 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
    */
   public List<String> getWorkloadOptionalArguments() { return Collections.EMPTY_LIST; }
 
+  /**
+   *  Returns connection-specific optional command line options.
+   *  @return the options split in lines.
+   */
+  public List<String> getConnectionOptionalArguments() {
+    return Arrays.asList(
+        "--username " + appConfig.dbUsername,
+        "--password " + appConfig.dbPassword,
+        "--ssl_cert " + appConfig.sslCert);
+  }
+
   ////////////// The following methods framework/helper methods for subclasses. ////////////////////
 
   /**

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -1057,7 +1057,17 @@ public class CmdLineOpts {
         footer.append(" ]\n");
       }
     }
+
+    List<String> optionalConnectionArgs = workload.getConnectionOptionalArguments();
+    footer.append("\n\t\tOther connection options (with default values):\n");
+
+    for (String line : optionalConnectionArgs) {
+      footer.append(optsPrefix + "[ ");
+      footer.append(line);
+      footer.append(" ]\n");
+    }
     footer.append("\n");
+
     System.out.println(footer.toString());
     System.exit(0);
   }


### PR DESCRIPTION
Currently, usage logs don't display connection options that need to be provided when authentication is required. 

Added the following connection options to be displayed when printing usage:
1. `--username`
2. `--password`
3.  `--ssl_cert`
