### PR TITLE
Fixed OOM for json metrics output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.yugabyte</groupId>
   <artifactId>yb-sample-apps</artifactId>
-  <version>1.3.10-SNAPSHOT</version>
+  <version>1.3.11-SNAPSHOT</version>
   <name>YB Sample Apps</name>
   <description>
     Sample applications for benchmarking YugaByte DB functionality on various workload types.

--- a/src/main/java/com/yugabyte/sample/common/metrics/Metric.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/Metric.java
@@ -14,21 +14,23 @@
 package com.yugabyte.sample.common.metrics;
 
 import com.google.gson.JsonObject;
-import com.yugabyte.sample.apps.AppBase;
 
 public class Metric {
+  private final boolean outputJsonMetrics;
 
   private final ReadableStatsMetric readableStatsMetric;
   private final JsonStatsMetric jsonStatsMetric;
 
-  public Metric(String name) {
+  public Metric(String name, boolean outputJsonMetrics) {
+    this.outputJsonMetrics = outputJsonMetrics;
+
     readableStatsMetric = new ReadableStatsMetric(name);
     jsonStatsMetric = new JsonStatsMetric(name);
   }
 
   public synchronized void observe(Observation o) {
     readableStatsMetric.accumulate(o.getCount(), o.getLatencyNanos());
-    if (AppBase.appConfig.outputJsonMetrics) jsonStatsMetric.observe(o);
+    if (outputJsonMetrics) jsonStatsMetric.observe(o);
   }
 
   public String getReadableMetricsAndReset() {

--- a/src/main/java/com/yugabyte/sample/common/metrics/Metric.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/Metric.java
@@ -14,10 +14,12 @@
 package com.yugabyte.sample.common.metrics;
 
 import com.google.gson.JsonObject;
+import com.yugabyte.sample.apps.AppBase;
 
 public class Metric {
-  private ReadableStatsMetric readableStatsMetric;
-  private JsonStatsMetric jsonStatsMetric;
+
+  private final ReadableStatsMetric readableStatsMetric;
+  private final JsonStatsMetric jsonStatsMetric;
 
   public Metric(String name) {
     readableStatsMetric = new ReadableStatsMetric(name);
@@ -26,7 +28,7 @@ public class Metric {
 
   public synchronized void observe(Observation o) {
     readableStatsMetric.accumulate(o.getCount(), o.getLatencyNanos());
-    jsonStatsMetric.observe(o);
+    if (AppBase.appConfig.outputJsonMetrics) jsonStatsMetric.observe(o);
   }
 
   public String getReadableMetricsAndReset() {

--- a/src/main/java/com/yugabyte/sample/common/metrics/MetricsTracker.java
+++ b/src/main/java/com/yugabyte/sample/common/metrics/MetricsTracker.java
@@ -52,7 +52,7 @@ public class MetricsTracker extends Thread {
 
   public synchronized void createMetric(MetricName metricName) {
     if (!metrics.containsKey(metricName)) {
-      metrics.put(metricName, new Metric(metricName.name()));
+      metrics.put(metricName, new Metric(metricName.name(), outputJsonMetrics));
     }
   }
 


### PR DESCRIPTION
In current version we accumulate JSON metrics even if we don't print them. This will cause problems if we use Cassandra workloads with lots of operations, this leads to lots of data in memory and out of memory exception.

This fix will enable data collecting only if `output_json_metrics` flag is set to true