### PR TITLE
Incorporate option to execute write YSQL sample app workloads indefinitely with upserts

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlDataLoad.java
@@ -225,6 +225,7 @@ public class SqlDataLoad extends AppBase {
 
             close(insConnection);
             insConnection = getPostgresConnection();
+            insConnection.createStatement().execute("set yb_enable_upsert_mode = true");
             preparedInsert = insConnection.prepareStatement(sb.toString());
         }
         return preparedInsert;

--- a/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlForeignKeysAndJoins.java
@@ -218,7 +218,9 @@ public class SqlForeignKeysAndJoins extends AppBase {
         if (preparedInsertUser == null) {
           String stmt = String.format("INSERT INTO %s (user_id, user_details) VALUES (?, ?);", getTable1Name());
           if (preparedInsertUser == null) {
-            preparedInsertUser = getPostgresConnection().prepareStatement(stmt);
+            Connection connection = getPostgresConnection();
+            connection.createStatement().execute("set yb_enable_upsert_mode = true");
+            preparedInsertUser = connection.prepareStatement(stmt);
           }
         }
         preparedInsertUserLocal = preparedInsertUser;
@@ -236,6 +238,7 @@ public class SqlForeignKeysAndJoins extends AppBase {
                                       getTable2Name());
           if (preparedInsertOrder == null) {
             Connection connection = getPostgresConnection();
+            connection.createStatement().execute("set yb_enable_upsert_mode = true");
             connection.setTransactionIsolation(Connection.TRANSACTION_SERIALIZABLE);
             preparedInsertOrder = connection.prepareStatement(stmt);
           }

--- a/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlGeoPartitionedTable.java
@@ -202,7 +202,9 @@ public class SqlGeoPartitionedTable extends AppBase {
 
   private PreparedStatement getPreparedInsert() throws Exception {
     if (preparedInsert == null) {
-      preparedInsert = getPostgresConnection().prepareStatement(
+      Connection connection = getPostgresConnection();
+      connection.createStatement().execute("set yb_enable_upsert_mode = true");
+      preparedInsert = connection.prepareStatement(
           String.format("INSERT INTO %s (region, k, v) VALUES (?, ?, ?)",
                         getTableName()));
     }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -154,8 +154,9 @@ public class SqlInserts extends AppBase {
     if (preparedInsert == null) {
       close(insConnection);
       insConnection = getPostgresConnection();
+      insConnection.createStatement().execute("set yb_enable_upsert_mode = true");
       preparedInsert = insConnection.prepareStatement(
-          String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()));
+          String.format("INSERT INTO %s (k, v) VALUES (?, ?) on conflict(k) do update set v=excluded.v;", getTableName()));
     }
     return preparedInsert;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -156,7 +156,7 @@ public class SqlInserts extends AppBase {
       insConnection = getPostgresConnection();
       insConnection.createStatement().execute("set yb_enable_upsert_mode = true");
       preparedInsert = insConnection.prepareStatement(
-          String.format("INSERT INTO %s (k, v) VALUES (?, ?) on conflict(k) do update set v=excluded.v;", getTableName()));
+          String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()));
     }
     return preparedInsert;
   }

--- a/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlSnapshotTxns.java
@@ -148,7 +148,9 @@ public class SqlSnapshotTxns extends AppBase {
                   String.format("INSERT INTO %s (k, v) VALUES (?, ?);", getTableName()) +
                   "COMMIT;";
     if (preparedInsert == null) {
-      preparedInsert = getPostgresConnection().prepareStatement(stmt);
+      Connection connection = getPostgresConnection();
+      connection.createStatement().execute("set yb_enable_upsert_mode = true");
+      preparedInsert = connection.prepareStatement(stmt);
     }
     return preparedInsert;
   }


### PR DESCRIPTION
**Problem:**
The YSQL sample app insert workloads today cannot be executed indefinitely in the long running  universes, since they fill the disk up and we either need to add more storage to the test universes which has cost implications or we must stop the workloads, drop tables and restart them which no longer makes the test long running since there is an interruption involved. 

**Solution:**
Set the flag `yb_enable_upsert_mode` to true for each of these workloads.

Caveat:
This flag does not work for workloads with secondary index. Filed a [ticket](https://yugabyte.atlassian.net/browse/DB-7848) for the same. 

Note:
The workload SqlUpdates does not require any change because it runs only update command and no inserts. Inserts are done via SQLInserts for SQLUpdates workloads.

[Performance comparison doc](https://docs.google.com/spreadsheets/d/1F-6gdanevxdXjL7RE6JRs0pnS9ia6a97AStQVITrm2M/edit#gid=0)

Disk Usage before starting the app:
35568	../yugabyte-data/node-1/disk-1
35568	../yugabyte-data/node-1
35572	../yugabyte-data/


Disk usage after running the app for a long time:
40364	../yugabyte-data/node-1/disk-1
40364	../yugabyte-data/node-1
40368	../yugabyte-data/