### PR TITLE
Enable row count validation for SqlInserts and YCQL workloads

### DIFF
--- a/src/main/java/com/yugabyte/sample/Main.java
+++ b/src/main/java/com/yugabyte/sample/Main.java
@@ -186,6 +186,7 @@ public class Main {
                                        IOType.Read, app.appConfig.printAllExceptions));
       }
 
+      app.recordExistingRowCount();
       // Start the reader and writer threads.
       for (IOPSThread iopsThread : iopsThreads) {
         iopsThread.start();
@@ -201,6 +202,7 @@ public class Main {
           LOG.error("Error waiting for thread join()", e);
         }
       }
+      app.verifyTotalRowsWritten();
     } finally {
       terminate();
     }

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -20,9 +20,7 @@ import java.net.UnknownHostException;
 import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -810,6 +808,18 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         metricsTracker.getMetric(MetricName.Read).observe(o);
       }
     }
+  }
+
+  public void verifyTotalRowsWritten() throws Exception {
+    throw new UnsupportedOperationException("Row count check is not supported for this workload");
+  }
+
+  public void recordExistingRowCount() throws Exception {
+    throw new UnsupportedOperationException("Row count check is not supported for this workload");
+  }
+
+  public String getTableName() {
+    return "AppBaseTable";
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -176,13 +176,6 @@ public abstract class CassandraKeyValueBase extends AppBase {
   protected long getRowCount() {
     ResultSet rs = getCassandraClient().execute("SELECT COUNT(*) FROM " + getTableName());
     List<Row> rows = rs.all();
-    if (rows.size() != 1) {
-      // If TTL is disabled, turn on correctness validation.
-      if (appConfig.tableTTLSeconds <= 0) {
-        LOG.fatal("Expected 1 row in result, got " + rows.size());
-      }
-      return 0;
-    }
     long actual = rows.get(0).getLong(0);
     LOG.info("Found " + actual + " rows in " + getTableName());
     return actual;

--- a/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/CassandraKeyValueBase.java
@@ -110,7 +110,7 @@ public abstract class CassandraKeyValueBase extends AppBase {
     ResultSet rs = getCassandraClient().execute(select);
     List<Row> rows = rs.all();
     if (rows.size() != 1) {
-      // If TTL is enabled, turn off correctness validation.
+      // If TTL is disabled, turn on correctness validation.
       if (appConfig.tableTTLSeconds <= 0) {
         LOG.fatal("Read key: " + key.asString() + " expected 1 row in result, got " + rows.size());
       }
@@ -171,6 +171,21 @@ public abstract class CassandraKeyValueBase extends AppBase {
       getSimpleLoadGenerator().recordWriteFailure(key);
       throw e;
     }
+  }
+
+  protected long getRowCount() {
+    ResultSet rs = getCassandraClient().execute("SELECT COUNT(*) FROM " + getTableName());
+    List<Row> rows = rs.all();
+    if (rows.size() != 1) {
+      // If TTL is disabled, turn on correctness validation.
+      if (appConfig.tableTTLSeconds <= 0) {
+        LOG.fatal("Expected 1 row in result, got " + rows.size());
+      }
+      return 0;
+    }
+    long actual = rows.get(0).getLong(0);
+    LOG.info("Found " + actual + " rows in " + getTableName());
+    return actual;
   }
 
   @Override

--- a/src/main/java/com/yugabyte/sample/apps/SQLAppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/SQLAppBase.java
@@ -1,0 +1,59 @@
+package com.yugabyte.sample.apps;
+
+import org.apache.log4j.Logger;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+public class SQLAppBase extends AppBase {
+
+    private Logger LOG = Logger.getLogger(SQLAppBase.class);
+
+    private long initialRowCount = 0;
+
+    protected long getRowCount() throws Exception {
+        long count = 0;
+        String table = getTableName();
+        Connection connection = getPostgresConnection();
+        try {
+            Statement statement = connection.createStatement();
+            String query = "SELECT COUNT(*) FROM " + table;
+            ResultSet rs = statement.executeQuery(query);
+            if (rs.next()) {
+                count = rs.getLong(1);
+                LOG.info("Row count in table " + table + ": " + count);
+            } else {
+                LOG.error("No result received!");
+            }
+        } finally {
+            if (connection != null) {
+                connection.close();
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public void verifyTotalRowsWritten() throws Exception {
+        if (appConfig.numKeysToWrite >= 0) {
+            String table = getTableName();
+            LOG.info("Verifying the inserts on table " + table + " (" + initialRowCount + " rows initially) ...");
+            LOG.info("appConfig.numKeysToWrite: " + appConfig.numKeysToWrite + ", numKeysWritten: " + numKeysWritten);
+            long actual = getRowCount();
+            long expected = numKeysWritten.get();
+            if (actual != (expected + initialRowCount)) {
+                LOG.fatal("New rows count does not match! Expected: " + (expected + initialRowCount) + ", actual: " + actual);
+            } else {
+                LOG.info("Table row count verified successfully");
+            }
+        }
+    }
+
+    @Override
+    public void recordExistingRowCount() throws Exception {
+        LOG.info("Recording the row count in table " + getTableName() + " if it exists ...");
+        initialRowCount = getRowCount();
+    }
+
+}

--- a/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
+++ b/src/main/java/com/yugabyte/sample/apps/SqlInserts.java
@@ -12,21 +12,18 @@
 //
 package com.yugabyte.sample.apps;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
+import java.sql.*;
 import java.util.Arrays;
 import java.util.List;
 
 import org.apache.log4j.Logger;
 
-import com.yugabyte.sample.apps.AppBase.TableOp;
 import com.yugabyte.sample.common.SimpleLoadGenerator.Key;
 
 /**
  * This workload writes and reads some random string keys from a postgresql table.
  */
-public class SqlInserts extends AppBase {
+public class SqlInserts extends SQLAppBase {
   private static final Logger LOG = Logger.getLogger(SqlInserts.class);
 
   // Static initialization of this workload's config. These are good defaults for getting a decent


### PR DESCRIPTION
- Enable row count validation for `SqlInserts` and YCQL workloads that extend from `CassandraKeyValue`.
- Introduced a new abstract class for YSQL workloads - `YSQLAppBase` - so that the YSQL specific behaviour can be moved to one place.
- If the row count validation fails, a FATAL statement is logged but the workload is allowed to continue.