### PR TITLE
Log at info level instead of throwing UnsupportedOperationException

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -811,11 +811,11 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
   }
 
   public void verifyTotalRowsWritten() throws Exception {
-    throw new UnsupportedOperationException("Row count check is not supported for this workload");
+    LOG.info("Row count check is not supported for this workload");
   }
 
   public void recordExistingRowCount() throws Exception {
-    throw new UnsupportedOperationException("Row count check is not supported for this workload");
+    LOG.info("Row count check is not supported for this workload");
   }
 
   public String getTableName() {


### PR DESCRIPTION
Log at info level instead of throwing UnsupportedOperationException in `AppBase`.
The workloads which do not override the methods `verifyTotalRowsWritten` and `recordExistingRowCount` were failing with message `"Row count check is not supported for this workload"`.
Now `AppBase` simply logs it at info level.