### PR TITLE
Grant permission to roles to create table on public schema

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -212,6 +212,15 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         String connectStr = String.format("%s//%s:%d/%s", url, contactPoint.getHost(),
                 contactPoint.getPort(),
                 database);
+        if (!username.equalsIgnoreCase("yugabyte") || !username.equalsIgnoreCase("postgres")){
+          Properties newProps = new Properties();
+          newProps.setProperty("user", "yugabyte");
+          Connection controlConnection = DriverManager.getConnection(connectStr, newProps);
+          Statement st = controlConnection.createStatement();
+          String grantPermission = String.format("grant create on schema public to %s with grant option;", username);
+          st.execute(grantPermission);
+          controlConnection.close();
+        }
         Connection connection = DriverManager.getConnection(connectStr, props);
         return connection;
       } catch (Exception e) {


### PR DESCRIPTION
PG15 changed the permissions and [revokes the CREATE permission from all users](https://www.postgresql.org/docs/15/ddl-schemas.html#DDL-SCHEMAS-PATTERNS) except a database owner from the public (or default) schema. This reults in the error: `ERROR: permission denied for schema public` while creating a table from the app when the user is not postgres or yugabyte.

This change is to grant the user create permissions from the app itself. 

Testing:
To test, create a new role on your cluster:
```
create role admin login password 'admin';
```
Run the yb-sample-apps and it should not give any error during create table