### PR TITLE
Grant permission to public schema fix for auth enabled cluster

### DIFF
--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -221,6 +221,7 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         if (!username.equalsIgnoreCase("yugabyte") && !username.equalsIgnoreCase("postgres")){
           Properties newProps = new Properties();
           newProps.setProperty("user", "yugabyte");
+          newProps.setProperty("password", appConfig.ybPassword);
           Connection controlConnection = DriverManager.getConnection(connectStr, newProps);
           Statement st = controlConnection.createStatement();
           String grantPermission = String.format("grant create on schema public to %s with grant option;", username);

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -224,6 +224,7 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
           Connection controlConnection = DriverManager.getConnection(connectStr, newProps);
           Statement st = controlConnection.createStatement();
           String grantPermission = String.format("grant create on schema public to %s with grant option;", username);
+          LOG.info("Granted create permission to user: " + username);
           st.execute(grantPermission);
           controlConnection.close();
         }

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -222,12 +222,18 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
           Properties newProps = new Properties();
           newProps.setProperty("user", "yugabyte");
           newProps.setProperty("password", appConfig.ybPassword);
-          Connection controlConnection = DriverManager.getConnection(connectStr, newProps);
-          Statement st = controlConnection.createStatement();
-          String grantPermission = String.format("grant create on schema public to %s with grant option;", username);
-          LOG.info("Granted create permission to user: " + username);
-          st.execute(grantPermission);
-          controlConnection.close();
+          Connection controlConnection = null;
+          try {
+            controlConnection = DriverManager.getConnection(connectStr, newProps);
+            Statement st = controlConnection.createStatement();
+            String grantPermission = String.format("grant create on schema public to %s with grant option;", username);
+            LOG.info("Granted create permission to user: " + username);
+            st.execute(grantPermission);
+          } finally {
+            if (controlConnection != null) {
+              controlConnection.close();
+            }
+          }
         }
         Connection connection = DriverManager.getConnection(connectStr, props);
         return connection;

--- a/src/main/java/com/yugabyte/sample/apps/AppBase.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppBase.java
@@ -218,7 +218,7 @@ public abstract class AppBase implements MetricsTracker.StatusMessageAppender {
         String connectStr = String.format("%s//%s:%d/%s", url, contactPoint.getHost(),
                 contactPoint.getPort(),
                 database);
-        if (!username.equalsIgnoreCase("yugabyte") || !username.equalsIgnoreCase("postgres")){
+        if (!username.equalsIgnoreCase("yugabyte") && !username.equalsIgnoreCase("postgres")){
           Properties newProps = new Properties();
           newProps.setProperty("user", "yugabyte");
           Connection controlConnection = DriverManager.getConnection(connectStr, newProps);

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -173,7 +173,7 @@ public class AppConfig {
   public String dbPassword = null;
 
   // Password to connect to the DB using yugabyte user.
-  public String ybPassword = null;
+  public String ybPassword = "yugabyte";
 
   // The number of client connections to establish to each host in the YugaByte DB cluster.
   public int concurrentClients = 4;

--- a/src/main/java/com/yugabyte/sample/apps/AppConfig.java
+++ b/src/main/java/com/yugabyte/sample/apps/AppConfig.java
@@ -172,6 +172,9 @@ public class AppConfig {
   // Password to connect to the DB.
   public String dbPassword = null;
 
+  // Password to connect to the DB using yugabyte user.
+  public String ybPassword = null;
+
   // The number of client connections to establish to each host in the YugaByte DB cluster.
   public int concurrentClients = 4;
 

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -350,6 +350,9 @@ public class CmdLineOpts {
       }
       AppBase.appConfig.dbPassword = commandLine.getOptionValue("password");
     }
+    if (commandLine.hasOption("yugabyte_password")) {
+      AppBase.appConfig.ybPassword = commandLine.getOptionValue("yugabyte_password");
+    }
     if (commandLine.hasOption("load_balance")) {
       AppBase.appConfig.loadBalance = Boolean.valueOf(commandLine.getOptionValue("load_balance"));
     }
@@ -792,6 +795,9 @@ public class CmdLineOpts {
     options.addOption("password", true,
         "The password to use when connecting to the database. " +
             "If this option is set, the --username option is required.");
+    options.addOption("yugabyte_password", true,
+            "The password to use when connecting to the database with user yugabyte. " +
+                    "This option is set when the --username is different from yugabyte or postgres");
     options.addOption("load_balance", true,
             "Set up YugabyteDB JDBC driver with in-built load balancing capability.");
     options.addOption("topology_keys", true,

--- a/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
+++ b/src/main/java/com/yugabyte/sample/common/CmdLineOpts.java
@@ -351,6 +351,10 @@ public class CmdLineOpts {
       AppBase.appConfig.dbPassword = commandLine.getOptionValue("password");
     }
     if (commandLine.hasOption("yugabyte_password")) {
+      if (commandLine.getOptionValue("username").equalsIgnoreCase("yugabyte") || commandLine.getOptionValue("username").equalsIgnoreCase("postgres")) {
+        LOG.error(("--yugabyte_password is not required when username is yugabyte or postgres"));
+        System.exit(1);
+      }
       AppBase.appConfig.ybPassword = commandLine.getOptionValue("yugabyte_password");
     }
     if (commandLine.hasOption("load_balance")) {
@@ -797,7 +801,7 @@ public class CmdLineOpts {
             "If this option is set, the --username option is required.");
     options.addOption("yugabyte_password", true,
             "The password to use when connecting to the database with user yugabyte. " +
-                    "This option is set when the --username is different from yugabyte or postgres");
+                    "This option is required when the user specified via --username option is other than 'yugabyte' and 'postgres'.");
     options.addOption("load_balance", true,
             "Set up YugabyteDB JDBC driver with in-built load balancing capability.");
     options.addOption("topology_keys", true,


### PR DESCRIPTION
This is a fix for PR #100 

For auth enabled cluster, implemented a command line option `yugabyte_password`, which is the password for the user yugabyte, that should be passed when the username is not `postgres` or `yugabyte` and auth is enabled for `yugabyte` user.

Also bug fix: Changed the condition from || to &&.